### PR TITLE
Making rowKey inclusivity configurable

### DIFF
--- a/client/src/main/java/com/flipkart/yak/client/AsyncStoreClientUtis.java
+++ b/client/src/main/java/com/flipkart/yak/client/AsyncStoreClientUtis.java
@@ -328,8 +328,8 @@ public class AsyncStoreClientUtis {
 
     byte[] startRowKey = keyDistributor.enrichKey(scanData.getStartRow(), scanData.getPartitionKey());
     byte[] stopRowKey = keyDistributor.enrichKey(scanData.getStopRow(), scanData.getPartitionKey());
-    scan.setStartRow(startRowKey);
-    scan.setStopRow(stopRowKey);
+    scan.withStartRow(startRowKey, scanData.shouldIncludeStartRow());
+    scan.withStopRow(stopRowKey, scanData.shouldIncludeStopRow());
 
     if (scanData.getCaching() == -1 || (scanData.getLimit() != -1 && scanData.getCaching() > scanData.getLimit())) {
       scan.setCaching(scanData.getLimit());

--- a/client/src/main/java/com/flipkart/yak/models/ScanData.java
+++ b/client/src/main/java/com/flipkart/yak/models/ScanData.java
@@ -28,6 +28,25 @@ public class ScanData {
   private List<ColTupple> columnfamilies = new ArrayList<>();
   private final String tableName;
   private byte[] partitionKey;
+  private boolean includeStopRow = false;
+  private boolean includeStartRow = true;
+
+  public boolean shouldIncludeStopRow() {
+      return includeStopRow;
+  }
+
+  public void setIncludeStopRow(boolean includeStopRow) {
+      this.includeStopRow = includeStopRow;
+  }
+
+  public boolean shouldIncludeStartRow() {
+      return includeStartRow;
+  }
+
+  public void setIncludeStartRow(boolean includeStartRow) {
+      this.includeStartRow = includeStartRow;
+  }
+
 
   public ScanData(String tableName) {
     this.tableName = tableName;


### PR DESCRIPTION
This PR introduces changes to support the modification of row inclusivity for startRow and stopRow in scan operations. 
To maintain backward compatibility, the default inclusivity is set to true for startRow and false for stopRow. These default values are based on the [HBase documentation](https://hbase.apache.org/2.3/apidocs/src-html/org/apache/hadoop/hbase/client/Scan.html#line.523)