### PR TITLE
rename routekey to routemeta

### DIFF
--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -171,11 +171,11 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   }
 
   @SuppressWarnings("java:S1193")
-  private List<SiteId> getSites(Optional<T> routeKey, boolean isRead)
+  private List<SiteId> getSites(Optional<T> routeMeta, boolean isRead)
       throws PipelinedStoreDataCorruptException {
     try {
       List<SiteId> sites = new ArrayList<>();
-      MasterSlaveReplicaSet replicaSet = route.getHotRouter().getReplicaSet(routeKey);
+      MasterSlaveReplicaSet replicaSet = route.getHotRouter().getReplicaSet(routeMeta);
 
       if (replicaSet != null && replicaSet.isValid()) {
         if (route instanceof IntentRoute) {
@@ -280,7 +280,7 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
    * {@inheritDoc}
    */
   @Override
-  public void increment(IncrementData incrementData, Optional<T> routeKey, Optional<U> intentData,
+  public void increment(IncrementData incrementData, Optional<T> routeMeta, Optional<U> intentData,
                         Optional<V> circuitBreakerSettings,
                         BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
 
@@ -288,7 +288,7 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.INCREMENT_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.INCREMENT_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<StoreOperationResponse<ResultMap>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(incrementData, site, value, INCREMENT_METHOD_NAME,
@@ -313,15 +313,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void put(StoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreaketrSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
+  @Override public void put(StoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<V> circuitBreaketrSettings,
+                            BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.PUT_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.PUT_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<StoreOperationResponse<Void>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(data, site, value, PUT_METHOD_NAME,
@@ -346,15 +346,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void put(List<StoreData> dataList, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreaketrSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+  @Override public void put(List<StoreData> dataList, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<V> circuitBreaketrSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.BATCH_PUT_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_PUT_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<List<StoreOperationResponse<Void>>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runBatchClientOperation(dataList, site, value, PUT_METHOD_NAME,
@@ -380,15 +380,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void checkAndPut(CheckAndStoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+  @Override public void checkAndPut(CheckAndStoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                                    Optional<V> circuitBreakerSettings,
+                                    BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.CAS_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.CAS_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<StoreOperationResponse<Boolean>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(data, site, value, CHECK_PUT_METHOD_NAME,
@@ -413,15 +413,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void append(StoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+  @Override public void append(StoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                               Optional<V> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.APPEND_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.APPEND_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<StoreOperationResponse<ResultMap>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(data, site, value, APPEND_METHOD_NAME,
@@ -446,15 +446,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void delete(List<DeleteData> data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+  @Override public void delete(List<DeleteData> data, Optional<T> routeMeta, Optional<U> intentData,
+                               Optional<V> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.BATCH_DELETE_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_DELETE_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<List<StoreOperationResponse<Void>>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runBatchClientOperation(data, site, value, DELETE_METHOD_NAME,
@@ -480,15 +480,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+  @Override public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeMeta, Optional<U> intentData,
+                                       Optional<V> circuitBreakerSettings,
+                                       BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.CHECK_DELETE_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.CHECK_DELETE_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, false);
+      List<SiteId> sites = getSites(routeMeta, false);
       CompletableFuture<StoreOperationResponse<Boolean>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(data, site, value, CHECK_DELETE_METHOD_NAME,
@@ -512,13 +512,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  public void scan(ScanData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
+  public void scan(ScanData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+                   BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.SCAN_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.SCAN_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, true);
+      List<SiteId> sites = getSites(routeMeta, true);
       CompletableFuture<StoreOperationResponse<Map<String, ResultMap>>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(data, site, value, SCAN_METHOD_NAME,
@@ -542,15 +542,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public <X extends GetRow> void get(X gets, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+  @Override public <X extends GetRow> void get(X gets, Optional<T> routeMeta, Optional<U> intentData,
+                                               Optional<V> circuitBreakerSettings,
+                                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.GET_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.GET_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, true);
+      List<SiteId> sites = getSites(routeMeta, true);
       CompletableFuture<StoreOperationResponse<ResultMap>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(gets, site, value, GET_METHOD_NAME,
@@ -575,15 +575,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void get(List<? extends GetRow> rows, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
+  @Override public void get(List<? extends GetRow> rows, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<V> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.GET_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_GET_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, true);
+      List<SiteId> sites = getSites(routeMeta, true);
       CompletableFuture<List<StoreOperationResponse<ResultMap>>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runBatchClientOperation(rows, site, value, GET_METHOD_NAME,
@@ -609,15 +609,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void getByIndex(GetColumnsMapByIndex get, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
+  @Override public void getByIndex(GetColumnsMapByIndex get, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<V> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.INDEX_GET_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.INDEX_GET_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, true);
+      List<SiteId> sites = getSites(routeMeta, true);
       CompletableFuture<StoreOperationResponse<List<ColumnsMap>>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(get, site, value, GET_INDEX_METHOD_NAME,
@@ -641,15 +641,15 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   /**
    * {@inheritDoc}
    */
-  @Override public void getByIndex(GetCellByIndex get, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
+  @Override public void getByIndex(GetCellByIndex get, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<V> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
 
     publisher.updateThreadCounter(executor.getActiveCount(), executor.getQueue().size(), executor.getPoolSize());
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.INDEX_GET_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.INDEX_GET_INIT);
     try {
-      List<SiteId> sites = getSites(routeKey, true);
+      List<SiteId> sites = getSites(routeMeta, true);
       CompletableFuture<StoreOperationResponse<List<Cell>>> future = CompletableFuture.completedFuture(null);
       for (SiteId site : sites) {
         future = future.thenComposeAsync(value -> runClientOperation(get, site, value, GET_INDEX_METHOD_NAME,
@@ -671,9 +671,9 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
     }
   }
 
-  @Override public List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeKey)
+  @Override public List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeMeta)
       throws PipelinedStoreDataCorruptException {
-    List<SiteId> sites = getSites(routeKey, true);
+    List<SiteId> sites = getSites(routeMeta, true);
 
     List<AsyncStoreClient> connections = new ArrayList<>();
     for (SiteId siteId : sites) {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/SyncYakPipelinedStore.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/SyncYakPipelinedStore.java
@@ -32,7 +32,7 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * Used to perform Increment operations on a single row atomically
    * If the column value does not yet exist it is initialized to amount and written to the specified column.
    *
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -43,12 +43,12 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @return {@link PipelinedResponse} with error response if fails, else {@link ResultMap} response
    */
   PipelinedResponse<StoreOperationResponse<ResultMap>> increment(IncrementData incrementData,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+      Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link StoreData} to put the row
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -61,13 +61,13 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
 
-  PipelinedResponse<StoreOperationResponse<Void>> put(StoreData data, Optional<T> routeKey,
+  PipelinedResponse<StoreOperationResponse<Void>> put(StoreData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link List} of {@link StoreData} to put the rows in batches
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -79,14 +79,14 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws ExecutionException   if upstream {@link java.util.concurrent.CompletableFuture} throws with failure
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
-  PipelinedResponse<List<StoreOperationResponse<Void>>> put(List<StoreData> data, Optional<T> routeKey,
+  PipelinedResponse<List<StoreOperationResponse<Void>>> put(List<StoreData> data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link CheckAndStoreData} checkes row/family/qualifier value matches the expected
    *                               value and updates if matches else responds with false
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -99,13 +99,13 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws ExecutionException   if upstream {@link java.util.concurrent.CompletableFuture} throws with failure
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
-  PipelinedResponse<StoreOperationResponse<Boolean>> checkAndPut(CheckAndStoreData data, Optional<T> routeKey,
+  PipelinedResponse<StoreOperationResponse<Boolean>> checkAndPut(CheckAndStoreData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link StoreData} object for identifying the row to append the family/qualifier to
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -118,13 +118,13 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws ExecutionException   if upstream {@link java.util.concurrent.CompletableFuture} throws with failure
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
-  PipelinedResponse<StoreOperationResponse<ResultMap>> append(StoreData data, Optional<T> routeKey,
+  PipelinedResponse<StoreOperationResponse<ResultMap>> append(StoreData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link List} of {@link DeleteData} to delete the rows in batches
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -137,14 +137,14 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws ExecutionException   if upstream {@link java.util.concurrent.CompletableFuture} throws with failure
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
-  PipelinedResponse<List<StoreOperationResponse<Void>>> delete(List<DeleteData> data, Optional<T> routeKey,
+  PipelinedResponse<List<StoreOperationResponse<Void>>> delete(List<DeleteData> data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link CheckAndStoreData} checkes row/family/qualifier value matches the expected
    *                               value and deletes if matches else responds with false
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -158,12 +158,12 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
   PipelinedResponse<StoreOperationResponse<Boolean>> checkAndDelete(CheckAndDeleteData data,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+      Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param data                   {@link ScanData} scan data to scan the table
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -175,14 +175,14 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws ExecutionException   if upstream {@link java.util.concurrent.CompletableFuture} throws with failure
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
-  PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> scan(ScanData data, Optional<T> routeKey,
+  PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> scan(ScanData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param <X>                    {@link GetRow} and its subclasses
    * @param row                    {@link GetRow} and its sub classes to fetch the row/family/qualifier
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -194,13 +194,13 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws ExecutionException   if upstream {@link java.util.concurrent.CompletableFuture} throws with failure
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
-  <X extends GetRow> PipelinedResponse<StoreOperationResponse<ResultMap>> get(X row, Optional<T> routeKey,
+  <X extends GetRow> PipelinedResponse<StoreOperationResponse<ResultMap>> get(X row, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param rows                   {@link List} of {@link GetRow} and its sub classes to fetch the row/family/qualifier
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -214,12 +214,12 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
   PipelinedResponse<List<StoreOperationResponse<ResultMap>>> get(List<? extends GetRow> rows,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+      Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param indexLookup            {@link GetColumnsMapByIndex} for looking up the {@link ColumnsMap} by index key
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -232,12 +232,12 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
   PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> getByIndex(GetColumnsMapByIndex indexLookup,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+      Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**
    * @param indexLookup            {@link GetCellByIndex} for looking up the {@link Cell} by index key
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -250,7 +250,7 @@ public interface SyncYakPipelinedStore<T, U extends IntentWriteRequest, V extend
    * @throws InterruptedException if upstream {@link java.util.concurrent.CompletableFuture} was interrupted
    */
   PipelinedResponse<StoreOperationResponse<List<Cell>>> getByIndex(GetCellByIndex indexLookup,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+      Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException;
 
   /**

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/SyncYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/SyncYakPipelinedStoreImpl.java
@@ -48,12 +48,12 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    */
   @Override
   public PipelinedResponse<StoreOperationResponse<ResultMap>> increment(IncrementData incrementData,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                        Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
       CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> completableFuture =
           new CompletableFuture<>();
 
-      pipelinedStore.increment(incrementData, routeKey, intentData, circuitBreakerSettings,
+      pipelinedStore.increment(incrementData, routeMeta, intentData, circuitBreakerSettings,
           (BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable>) (response, error) -> {
               if (error != null) {
                   completableFuture.completeExceptionally(error);
@@ -71,13 +71,13 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
   /**
    * {@inheritDoc}
    */
-  @Override public PipelinedResponse<StoreOperationResponse<Void>> put(StoreData data, Optional<T> routeKey,
+  @Override public PipelinedResponse<StoreOperationResponse<Void>> put(StoreData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> completableFuture = new CompletableFuture<>();
 
-    pipelinedStore.put(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.put(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -95,14 +95,14 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
   /**
    * {@inheritDoc}
    */
-  @Override public PipelinedResponse<List<StoreOperationResponse<Void>>> put(List<StoreData> data, Optional<T> routeKey,
+  @Override public PipelinedResponse<List<StoreOperationResponse<Void>>> put(List<StoreData> data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
 
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.put(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.put(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -121,11 +121,11 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public PipelinedResponse<StoreOperationResponse<Boolean>> checkAndPut(CheckAndStoreData data,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                                  Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> completableFuture = new CompletableFuture<>();
 
-    pipelinedStore.checkAndPut(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.checkAndPut(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -143,14 +143,14 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
   /**
    * {@inheritDoc}
    */
-  @Override public PipelinedResponse<StoreOperationResponse<ResultMap>> append(StoreData data, Optional<T> routeKey,
+  @Override public PipelinedResponse<StoreOperationResponse<ResultMap>> append(StoreData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.append(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.append(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -169,13 +169,13 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public PipelinedResponse<List<StoreOperationResponse<Void>>> delete(List<DeleteData> data,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                                Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
 
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.delete(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.delete(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -194,11 +194,11 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public PipelinedResponse<StoreOperationResponse<Boolean>> checkAndDelete(CheckAndDeleteData data,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                                     Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> completableFuture = new CompletableFuture<>();
 
-    pipelinedStore.checkAndDelete(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.checkAndDelete(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -213,13 +213,13 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
     return completableFuture.get(writeTimeoutInMillis, TimeUnit.MILLISECONDS);
   }
 
-  @Override public PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> scan(ScanData data, Optional<T> routeKey,
+  @Override public PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> scan(ScanData data, Optional<T> routeMeta,
       Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.scan(data, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.scan(data, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -238,12 +238,12 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public <X extends GetRow> PipelinedResponse<StoreOperationResponse<ResultMap>> get(X row,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                                               Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.get(row, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.get(row, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -262,13 +262,13 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public PipelinedResponse<List<StoreOperationResponse<ResultMap>>> get(List<? extends GetRow> rows,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                                  Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
 
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.get(rows, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.get(rows, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -287,13 +287,13 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> getByIndex(
-      GetColumnsMapByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings)
+          GetColumnsMapByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+          Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);
@@ -312,12 +312,12 @@ public class SyncYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V extend
    * {@inheritDoc}
    */
   @Override public PipelinedResponse<StoreOperationResponse<List<Cell>>> getByIndex(GetCellByIndex indexLookup,
-      Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings)
+                                                                                    Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings)
       throws ExecutionException, InterruptedException, TimeoutException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> completableFuture =
         new CompletableFuture<>();
 
-    pipelinedStore.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings,
+    pipelinedStore.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings,
             (BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable>) (response, error) -> {
               if (error != null) {
                 completableFuture.completeExceptionally(error);

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/YakPipelinedStore.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/YakPipelinedStore.java
@@ -59,13 +59,13 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    * @param handler       Callback method to collect the response when the asynchronous response is ready
    *
    */
-  void increment(IncrementData incrementData, Optional<T> routeKey, Optional<U> intentData,
+  void increment(IncrementData incrementData, Optional<T> routeMeta, Optional<U> intentData,
                  Optional<V> circuitBreakerSettings,
                  BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler);
 
   /**
    * @param data                   {@link StoreData} to put the row
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -73,12 +73,12 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void put(StoreData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+  void put(StoreData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler);
 
   /**
    * @param data                   {@link List} of {@link StoreData} to put the rows in batches
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -86,14 +86,14 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void put(List<StoreData> data, Optional<T> routeKey, Optional<U> intentData,
+  void put(List<StoreData> data, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler);
 
   /**
    * @param data                   {@link CheckAndStoreData} checkes row/family/qualifier value matches the expected
    *                               value and updates if matches else responds with false
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -101,13 +101,13 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void checkAndPut(CheckAndStoreData data, Optional<T> routeKey, Optional<U> intentData,
+  void checkAndPut(CheckAndStoreData data, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler);
 
   /**
    * @param data                   {@link StoreData} object for identifying the row to append the family/qualifier to
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -115,12 +115,12 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void append(StoreData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+  void append(StoreData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler);
 
   /**
    * @param data                   {@link List} of {@link DeleteData} to delete the rows in batches
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -128,14 +128,14 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void delete(List<DeleteData> data, Optional<T> routeKey, Optional<U> intentData,
+  void delete(List<DeleteData> data, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler);
 
   /**
    * @param data                   {@link CheckAndStoreData} checkes row/family/qualifier value matches the expected
    *                               value and deletes if matches else responds with false
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -143,7 +143,7 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void checkAndDelete(CheckAndDeleteData data, Optional<T> routeKey, Optional<U> intentData,
+  void checkAndDelete(CheckAndDeleteData data, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler);
 
@@ -151,7 +151,7 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    * Scan the table with {@link ScanData}
    *
    * @param data                   {@link ScanData} scan query
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -159,13 +159,13 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void scan(ScanData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+  void scan(ScanData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler);
 
   /**
    * @param <X>                    {@link GetRow} and its subclasses
    * @param row                    {@link GetRow} and its sub classes to fetch the row/family/qualifier
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -173,13 +173,13 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  <X extends GetRow> void get(X row, Optional<T> routeKey, Optional<U> intentData,
+  <X extends GetRow> void get(X row, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler);
 
   /**
    * @param rows                   {@link List} of {@link GetRow} and its sub classes to fetch the row/family/qualifier
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -187,13 +187,13 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void get(List<? extends GetRow> rows, Optional<T> routeKey, Optional<U> intentData,
+  void get(List<? extends GetRow> rows, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler);
 
   /**
    * @param indexLookup            {@link GetColumnsMapByIndex} for looking up the {@link ColumnsMap} by index key
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -201,13 +201,13 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
+  void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler);
 
   /**
    * @param indexLookup            {@link GetCellByIndex} for looking up the {@link Cell} by index key
-   * @param routeKey               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
+   * @param routeMeta               An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by
    *                               {@link HotRouter} for this operation
    * @param intentData             An {@link Optional} {@link IntentWriteRequest} which is written by specific
    *                               implementation {@link IntentStoreClient}
@@ -215,14 +215,14 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    *                               wrapped around by circuit breaker decorator
    * @param handler                Callback method to collect the response when the asynchronous response is ready
    */
-  void getByIndex(GetCellByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
+  void getByIndex(GetCellByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
       Optional<V> circuitBreakerSettings,
       BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler);
 
   /**
    * Get underlying AsyncStoreClient that is going to be used for making query for a specific route key.
    *
-   * @param routeKey An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by {@link
+   * @param routeMeta An {@link Optional} route key which is used for selecting the {@link ReplicaSet} by {@link
    *                 HotRouter} for this operation
    *
    * @return list of store client instances which will be tried out in sequence based on route key
@@ -230,7 +230,7 @@ public interface YakPipelinedStore<T, U extends IntentWriteRequest, V extends Ci
    * @throws PipelinedStoreDataCorruptException on handling data corruptions which should be recovered outside of store
    *                                            client
    */
-  List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeKey)
+  List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeMeta)
       throws PipelinedStoreDataCorruptException;
 
   /**

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/circuitbreakers/CircuitBreakerDecorator.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/circuitbreakers/CircuitBreakerDecorator.java
@@ -24,81 +24,81 @@ public abstract class CircuitBreakerDecorator<T, U extends IntentWriteRequest, V
     this.pipelinedStore = pipelinedStore;
   }
 
-  @Override public void increment(IncrementData incrementData, Optional<T> routeKey, Optional<U> intentData,
+  @Override public void increment(IncrementData incrementData, Optional<T> routeMeta, Optional<U> intentData,
                                   Optional<V> circuitBreakerSettings,
                                   BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
-    pipelinedStore.increment(incrementData, routeKey, intentData, circuitBreakerSettings, handler);
+    pipelinedStore.increment(incrementData, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
   @Override
-  public void put(StoreData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
-    pipelinedStore.put(data, routeKey, intentData, circuitBreakerSettings, handler);
+  public void put(StoreData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+                  BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
+    pipelinedStore.put(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void put(List<StoreData> data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
-    pipelinedStore.put(data, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void put(List<StoreData> data, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<V> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+    pipelinedStore.put(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void checkAndPut(CheckAndStoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
-    pipelinedStore.checkAndPut(data, routeKey, intentData, circuitBreakerSettings, handler);
-  }
-
-  @Override
-  public void append(StoreData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
-    pipelinedStore.append(data, routeKey, intentData, circuitBreakerSettings, handler);
-  }
-
-  @Override public void delete(List<DeleteData> data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
-    pipelinedStore.delete(data, routeKey, intentData, circuitBreakerSettings, handler);
-  }
-
-  @Override public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
-    pipelinedStore.checkAndDelete(data, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void checkAndPut(CheckAndStoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                                    Optional<V> circuitBreakerSettings,
+                                    BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+    pipelinedStore.checkAndPut(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
   @Override
-  public void scan(ScanData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
-    pipelinedStore.scan(data, routeKey, intentData, circuitBreakerSettings, handler);
+  public void append(StoreData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+                     BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+    pipelinedStore.append(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public <X extends GetRow> void get(X row, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
-    pipelinedStore.get(row, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void delete(List<DeleteData> data, Optional<T> routeMeta, Optional<U> intentData,
+                               Optional<V> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+    pipelinedStore.delete(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void get(List<? extends GetRow> rows, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
-    pipelinedStore.get(rows, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeMeta, Optional<U> intentData,
+                                       Optional<V> circuitBreakerSettings,
+                                       BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+    pipelinedStore.checkAndDelete(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
-    pipelinedStore.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override
+  public void scan(ScanData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+                   BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
+    pipelinedStore.scan(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void getByIndex(GetCellByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
-    pipelinedStore.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public <X extends GetRow> void get(X row, Optional<T> routeMeta, Optional<U> intentData,
+                                               Optional<V> circuitBreakerSettings,
+                                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+    pipelinedStore.get(row, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeKey)
+  @Override public void get(List<? extends GetRow> rows, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<V> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
+    pipelinedStore.get(rows, routeMeta, intentData, circuitBreakerSettings, handler);
+  }
+
+  @Override public void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<V> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
+    pipelinedStore.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings, handler);
+  }
+
+  @Override public void getByIndex(GetCellByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<V> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
+    pipelinedStore.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings, handler);
+  }
+
+  @Override public List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeMeta)
       throws PipelinedStoreDataCorruptException {
-    return pipelinedStore.getAsyncStoreClient(routeKey);
+    return pipelinedStore.getAsyncStoreClient(routeMeta);
   }
 
   @Override public AsyncStoreClient getAsyncStoreClient(SiteId siteId) {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/circuitbreakers/HystrixCircuitBreakerDecorator.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/circuitbreakers/HystrixCircuitBreakerDecorator.java
@@ -63,7 +63,7 @@ public class HystrixCircuitBreakerDecorator<T, U extends IntentWriteRequest>
   }
 
   @Override
-  public void increment(IncrementData incrementData, Optional<T> routeKey,
+  public void increment(IncrementData incrementData, Optional<T> routeMeta,
                         Optional<U> intentData, Optional<HystrixSettings> circuitBreakerSettings,
                         BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
 
@@ -71,223 +71,223 @@ public class HystrixCircuitBreakerDecorator<T, U extends IntentWriteRequest>
 
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-        Stream.of(incrementData.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+        Stream.of(incrementData.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
           .collect(Collectors.toList());
       List<Object> parameters =
-        Stream.of(incrementData, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+        Stream.of(incrementData, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
         new PipelinedRequest(INCREMENT_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.increment(incrementData, routeKey, intentData, circuitBreakerSettings, handler);
+      super.increment(incrementData, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void put(StoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
+  @Override public void put(StoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<HystrixSettings> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler, new PipelinedRequest(PUT_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.put(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.put(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void put(List<StoreData> data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+  @Override public void put(List<StoreData> data, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<HystrixSettings> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
 
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(List.class, routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(List.class, routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler, new PipelinedRequest(PUT_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.put(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.put(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void checkAndPut(CheckAndStoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+  @Override public void checkAndPut(CheckAndStoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                                    Optional<HystrixSettings> circuitBreakerSettings,
+                                    BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
 
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
           new PipelinedRequest(CHECK_PUT_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.checkAndPut(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.checkAndPut(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void append(StoreData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+  @Override public void append(StoreData data, Optional<T> routeMeta, Optional<U> intentData,
+                               Optional<HystrixSettings> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
           new PipelinedRequest(APPEND_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.append(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.append(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
 
   }
 
-  @Override public void delete(List<DeleteData> data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+  @Override public void delete(List<DeleteData> data, Optional<T> routeMeta, Optional<U> intentData,
+                               Optional<HystrixSettings> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(List.class, routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(List.class, routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
           new PipelinedRequest(DELETE_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.delete(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.delete(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+  @Override public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeMeta, Optional<U> intentData,
+                                       Optional<HystrixSettings> circuitBreakerSettings,
+                                       BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
           new PipelinedRequest(CHECK_DELETE_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.checkAndDelete(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.checkAndDelete(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void scan(ScanData data, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
+  @Override public void scan(ScanData data, Optional<T> routeMeta, Optional<U> intentData,
+                             Optional<HystrixSettings> circuitBreakerSettings,
+                             BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(data, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(data, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler, new PipelinedRequest(SCAN_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.scan(data, routeKey, intentData, circuitBreakerSettings, handler);
+      super.scan(data, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public <X extends GetRow> void get(X row, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+  @Override public <X extends GetRow> void get(X row, Optional<T> routeMeta, Optional<U> intentData,
+                                               Optional<HystrixSettings> circuitBreakerSettings,
+                                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       Class<?> clazz = (!row.getClass().equals(GetRow.class)) ? GetRow.class : row.getClass();
       List<Class> parameterTypes =
-          Stream.of(clazz, routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(clazz, routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(row, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(row, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler, new PipelinedRequest(GET_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.get(row, routeKey, intentData, circuitBreakerSettings, handler);
+      super.get(row, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void get(List<? extends GetRow> rows, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
+  @Override public void get(List<? extends GetRow> rows, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<HystrixSettings> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes =
-          Stream.of(List.class, routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          Stream.of(List.class, routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
               .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(rows, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(rows, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler, new PipelinedRequest(GET_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.get(rows, routeKey, intentData, circuitBreakerSettings, handler);
+      super.get(rows, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
+  @Override public void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<HystrixSettings> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes = Stream
-          .of(indexLookup.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          .of(indexLookup.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
           .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(indexLookup, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(indexLookup, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
           new PipelinedRequest(GET_INDEX_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings, handler);
+      super.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 
-  @Override public void getByIndex(GetCellByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<HystrixSettings> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
+  @Override public void getByIndex(GetCellByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<HystrixSettings> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
 
     Optional<HystrixSettings> settings = getHystrixSettings(circuitBreakerSettings, intentData);
     if (settings.isPresent()) {
       List<Class> parameterTypes = Stream
-          .of(indexLookup.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
+          .of(indexLookup.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass())
           .collect(Collectors.toList());
       List<Object> parameters =
-          Stream.of(indexLookup, routeKey, intentData, circuitBreakerSettings).collect(Collectors.toList());
+          Stream.of(indexLookup, routeMeta, intentData, circuitBreakerSettings).collect(Collectors.toList());
 
       handleHystrixRequest(settings.get(), handler,
           new PipelinedRequest(GET_INDEX_METHOD_NAME, parameterTypes, parameters));
     } else {
-      super.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings, handler);
+      super.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings, handler);
     }
   }
 }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/intent/IntentStoreDecorator.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/intent/IntentStoreDecorator.java
@@ -27,45 +27,45 @@ public abstract class IntentStoreDecorator<T, U extends IntentWriteRequest, V ex
     this.intentStoreClient = intentStoreClient;
   }
 
-  @Override public void increment(IncrementData incrementData, Optional<T> routeKey, Optional<U> intentData,
+  @Override public void increment(IncrementData incrementData, Optional<T> routeMeta, Optional<U> intentData,
                                   Optional<V> circuitBreakerSettings,
                                   BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
-    pipelinedStore.increment(incrementData, routeKey, intentData, circuitBreakerSettings, handler);
+    pipelinedStore.increment(incrementData, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
   @Override
-  public void scan(ScanData data, Optional<T> routeKey, Optional<U> intentData, Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
-    pipelinedStore.scan(data, routeKey, intentData, circuitBreakerSettings, handler);
+  public void scan(ScanData data, Optional<T> routeMeta, Optional<U> intentData, Optional<V> circuitBreakerSettings,
+                   BiConsumer<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>, Throwable> handler) {
+    pipelinedStore.scan(data, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public <X extends GetRow> void get(X row, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
-    pipelinedStore.get(row, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public <X extends GetRow> void get(X row, Optional<T> routeMeta, Optional<U> intentData,
+                                               Optional<V> circuitBreakerSettings,
+                                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+    pipelinedStore.get(row, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void get(List<? extends GetRow> rows, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
-    pipelinedStore.get(rows, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void get(List<? extends GetRow> rows, Optional<T> routeMeta, Optional<U> intentData,
+                            Optional<V> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>, Throwable> handler) {
+    pipelinedStore.get(rows, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
-    pipelinedStore.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void getByIndex(GetColumnsMapByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<V> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>, Throwable> handler) {
+    pipelinedStore.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public void getByIndex(GetCellByIndex indexLookup, Optional<T> routeKey, Optional<U> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
-    pipelinedStore.getByIndex(indexLookup, routeKey, intentData, circuitBreakerSettings, handler);
+  @Override public void getByIndex(GetCellByIndex indexLookup, Optional<T> routeMeta, Optional<U> intentData,
+                                   Optional<V> circuitBreakerSettings,
+                                   BiConsumer<PipelinedResponse<StoreOperationResponse<List<Cell>>>, Throwable> handler) {
+    pipelinedStore.getByIndex(indexLookup, routeMeta, intentData, circuitBreakerSettings, handler);
   }
 
-  @Override public List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeKey)
+  @Override public List<AsyncStoreClient> getAsyncStoreClient(Optional<T> routeMeta)
       throws PipelinedStoreDataCorruptException {
-    return pipelinedStore.getAsyncStoreClient(routeKey);
+    return pipelinedStore.getAsyncStoreClient(routeMeta);
   }
 
   @Override public AsyncStoreClient getAsyncStoreClient(SiteId siteId) {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/intent/YakIntentStoreDecorator.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/decorator/intent/YakIntentStoreDecorator.java
@@ -60,89 +60,89 @@ public class YakIntentStoreDecorator<T, V extends CircuitBreakerSettings>
   }
 
   @Override
-  public void increment(IncrementData incrementData, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
+  public void increment(IncrementData incrementData, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
                         Optional<V> circuitBreakerSettings,
                         BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
     List<Class> parameterTypes = Stream
-      .of(incrementData.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
+      .of(incrementData.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
         BiConsumer.class).collect(Collectors.toList());
     List<Object> parameters =
-      Stream.of(incrementData, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+      Stream.of(incrementData, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(INCREMENT_METHOD_NAME, parameterTypes, parameters));
   }
 
-  @Override public void put(StoreData data, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
+  @Override public void put(StoreData data, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
+                            Optional<V> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable> handler) {
 
     List<Class> parameterTypes = Stream
-        .of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
+        .of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
             BiConsumer.class).collect(Collectors.toList());
     List<Object> parameters =
-        Stream.of(data, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+        Stream.of(data, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(PUT_METHOD_NAME, parameterTypes, parameters));
   }
 
-  @Override public void put(List<StoreData> data, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+  @Override public void put(List<StoreData> data, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
+                            Optional<V> circuitBreakerSettings,
+                            BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
     List<Class> parameterTypes = Stream
-        .of(List.class, routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(), BiConsumer.class)
+        .of(List.class, routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(), BiConsumer.class)
         .collect(Collectors.toList());
     List<Object> parameters =
-        Stream.of(data, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+        Stream.of(data, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(PUT_METHOD_NAME, parameterTypes, parameters));
   }
 
   @Override
-  public void checkAndPut(CheckAndStoreData data, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+  public void checkAndPut(CheckAndStoreData data, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
+                          Optional<V> circuitBreakerSettings,
+                          BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
     List<Class> parameterTypes = Stream
-        .of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
+        .of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
             BiConsumer.class).collect(Collectors.toList());
     List<Object> parameters =
-        Stream.of(data, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+        Stream.of(data, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(CHECK_PUT_METHOD_NAME, parameterTypes, parameters));
   }
 
-  @Override public void append(StoreData data, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
+  @Override public void append(StoreData data, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
+                               Optional<V> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable> handler) {
     List<Class> parameterTypes = Stream
-        .of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
+        .of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
             BiConsumer.class).collect(Collectors.toList());
     List<Object> parameters =
-        Stream.of(data, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+        Stream.of(data, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(APPEND_METHOD_NAME, parameterTypes, parameters));
   }
 
-  @Override public void delete(List<DeleteData> data, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
+  @Override public void delete(List<DeleteData> data, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
+                               Optional<V> circuitBreakerSettings,
+                               BiConsumer<PipelinedResponse<List<StoreOperationResponse<Void>>>, Throwable> handler) {
     List<Class> parameterTypes = Stream
-        .of(List.class, routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(), BiConsumer.class)
+        .of(List.class, routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(), BiConsumer.class)
         .collect(Collectors.toList());
     List<Object> parameters =
-        Stream.of(data, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+        Stream.of(data, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(DELETE_METHOD_NAME, parameterTypes, parameters));
   }
 
   @Override
-  public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeKey, Optional<YakIntentWriteRequest> intentData,
-      Optional<V> circuitBreakerSettings,
-      BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
+  public void checkAndDelete(CheckAndDeleteData data, Optional<T> routeMeta, Optional<YakIntentWriteRequest> intentData,
+                             Optional<V> circuitBreakerSettings,
+                             BiConsumer<PipelinedResponse<StoreOperationResponse<Boolean>>, Throwable> handler) {
     List<Class> parameterTypes = Stream
-        .of(data.getClass(), routeKey.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
+        .of(data.getClass(), routeMeta.getClass(), intentData.getClass(), circuitBreakerSettings.getClass(),
             BiConsumer.class).collect(Collectors.toList());
     List<Object> parameters =
-        Stream.of(data, routeKey, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
+        Stream.of(data, routeMeta, intentData, circuitBreakerSettings, handler).collect(Collectors.toList());
 
     handleIntentWrite(intentData, handler, new PipelinedRequest(CHECK_DELETE_METHOD_NAME, parameterTypes, parameters));
   }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/intent/YakIntentStoreClientImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/intent/YakIntentStoreClientImpl.java
@@ -57,7 +57,7 @@ public class YakIntentStoreClientImpl implements
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.PUT_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.PUT_INIT);
 
-    pipelinedStore.put(request.getStoreData(), request.getRouteKeyOptional(), Optional.empty(), Optional.empty(),
+    pipelinedStore.put(request.getStoreData(), request.getRouteMetaOptional(), Optional.empty(), Optional.empty(),
             (BiConsumer<PipelinedResponse<StoreOperationResponse<Void>>, Throwable>) (response, error) -> {
           try {
             handler.accept(response, error);
@@ -75,7 +75,7 @@ public class YakIntentStoreClientImpl implements
     Timer.Context timer = publisher.getTimer(PipelinedClientMetricsPublisher.GET_TIMER);
     publisher.incrementMetric(PipelinedClientMetricsPublisher.GET_INIT);
 
-    pipelinedStore.get(request.getRow(), request.getRouteKeyOptional(), Optional.empty(), Optional.empty(),
+    pipelinedStore.get(request.getRow(), request.getRouteMetaOptional(), Optional.empty(), Optional.empty(),
             (BiConsumer<PipelinedResponse<StoreOperationResponse<ResultMap>>, Throwable>) (response, error) -> {
           try {
             handler.accept(response, error);

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/IntentReadRequest.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/IntentReadRequest.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 @SuppressWarnings("java:S3740")
 public abstract class IntentReadRequest<T, U> extends IntentSettings {
-  public IntentReadRequest(Optional<T> routeKeyOptional, Optional<U> circuitBreakerOptional) {
-    super(routeKeyOptional, circuitBreakerOptional);
+  public IntentReadRequest(Optional<T> routeMetaOptional, Optional<U> circuitBreakerOptional) {
+    super(routeMetaOptional, circuitBreakerOptional);
   }
 }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/IntentSettings.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/IntentSettings.java
@@ -3,11 +3,11 @@ package com.flipkart.yak.client.pipelined.models;
 import java.util.Optional;
 
 public class IntentSettings<T, U extends CircuitBreakerSettings> {
-  protected Optional<T> routeKeyOptional;
+  protected Optional<T> routeMetaOptional;
   protected Optional<U> circuitBreakerOptional;
 
-  public IntentSettings(Optional<T> routeKeyOptional, Optional<U> circuitBreakerOptional) {
-    this.routeKeyOptional = routeKeyOptional;
+  public IntentSettings(Optional<T> routeMetaOptional, Optional<U> circuitBreakerOptional) {
+    this.routeMetaOptional = routeMetaOptional;
     this.circuitBreakerOptional = circuitBreakerOptional;
   }
 
@@ -15,7 +15,7 @@ public class IntentSettings<T, U extends CircuitBreakerSettings> {
     return circuitBreakerOptional;
   }
 
-  public Optional<T> getRouteKeyOptional() {
-    return routeKeyOptional;
+  public Optional<T> getRouteMetaOptional() {
+    return routeMetaOptional;
   }
 }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/IntentWriteRequest.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/IntentWriteRequest.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 @SuppressWarnings("java:S3740")
 public abstract class IntentWriteRequest<T, U> extends IntentSettings {
-  public IntentWriteRequest(Optional<T> routeKeyOptional, Optional<U> circuitBreakerOptional) {
-    super(routeKeyOptional, circuitBreakerOptional);
+  public IntentWriteRequest(Optional<T> routeMetaOptional, Optional<U> circuitBreakerOptional) {
+    super(routeMetaOptional, circuitBreakerOptional);
   }
 }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/YakIntentReadRequest.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/YakIntentReadRequest.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 public class YakIntentReadRequest<T, U extends CircuitBreakerSettings> extends IntentReadRequest {
   private GetRow row;
 
-  public YakIntentReadRequest(GetRow row, Optional<T> routeKeyOptional, Optional<U> circuitBreakerOptional) {
-    super(routeKeyOptional, circuitBreakerOptional);
+  public YakIntentReadRequest(GetRow row, Optional<T> routeMetaOptional, Optional<U> circuitBreakerOptional) {
+    super(routeMetaOptional, circuitBreakerOptional);
     this.row = row;
   }
 

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/YakIntentWriteRequest.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/YakIntentWriteRequest.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 public class YakIntentWriteRequest<T, U extends CircuitBreakerSettings> extends IntentWriteRequest {
   private StoreData storeData;
 
-  public YakIntentWriteRequest(StoreData storeData, Optional<T> routeKeyOptional, Optional<U> circuitBreakerOptional) {
-    super(routeKeyOptional, circuitBreakerOptional);
+  public YakIntentWriteRequest(StoreData storeData, Optional<T> routeMetaOptional, Optional<U> circuitBreakerOptional) {
+    super(routeMetaOptional, circuitBreakerOptional);
     this.storeData = storeData;
   }
 

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/route/HeaderBasedHotRouter.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/route/HeaderBasedHotRouter.java
@@ -16,10 +16,10 @@ public class HeaderBasedHotRouter implements HotRouter<MasterSlaveReplicaSet, Ma
     public HeaderBasedHotRouter() {}
 
     @Override
-    public MasterSlaveReplicaSet getReplicaSet(Optional<Map<DataCenter, MasterSlaveReplicaSet>> replicaSetMapOptional) {
+    public MasterSlaveReplicaSet getReplicaSet(Optional<Map<DataCenter, MasterSlaveReplicaSet>> routeMeta) {
 
-        if (replicaSetMapOptional.isPresent()) {
-            Map<DataCenter, MasterSlaveReplicaSet> replicasetMap = replicaSetMapOptional.get();
+        if (routeMeta.isPresent()) {
+            Map<DataCenter, MasterSlaveReplicaSet> replicasetMap = routeMeta.get();
             Baggage baggage = Baggage.current();
             String dataCenterString = baggage.getEntryValue(Constants.X_PINNED_DC);
 

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/route/HotRouter.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/route/HotRouter.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface HotRouter<T extends ReplicaSet, U> {
 
-  T getReplicaSet(Optional<U> routeKey) throws PipelinedStoreDataCorruptException;
+  T getReplicaSet(Optional<U> routeMeta) throws PipelinedStoreDataCorruptException;
 }

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientAppendTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientAppendTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.ResultMap;
 import com.flipkart.yak.models.StoreData;
@@ -58,7 +57,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
   @Test public void testAppendToRegion1SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteAClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.append(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -75,7 +74,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
           throws ExecutionException, InterruptedException, TimeoutException {
     when(region1SiteAClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response =
-        syncStore.append(data, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.append(data, routeMetaChOptional, intentData, hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -90,7 +89,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
   @Test public void testAppendToRegion1SiteAWithNoIntent() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteAClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.append(data, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -112,7 +111,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFuture);
 
-    store.append(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     try {
       future.get();
       assertTrue("Should have thrown exception", false || (!runWithIntent));
@@ -128,7 +127,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
   @Test public void testAppendToRegion2SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region2SiteAClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.append(data, routeKeyHydOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaHydOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -150,7 +149,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.append(eq(data))).thenReturn(respFuture);
 
-    store.append(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
@@ -171,7 +170,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.append(eq(data))).thenReturn(respFuture);
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response =
-        syncStore.append(data, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.append(data, routeMetaChOptional, intentData, hystrixSettings);
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
@@ -211,7 +210,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteAClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
     when(region1SiteBClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.append(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -236,7 +235,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException("Failed"));
     when(region1SiteAClient.append(eq(data))).thenReturn(respFuture);
     when(region1SiteBClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.append(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -262,7 +261,7 @@ public class PipelinedClientAppendTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.append(eq(data))).thenReturn(respFuture);
     when(region1SiteBClient.append(eq(data))).thenReturn(respFuture);
     when(region2SiteAClient.append(eq(data))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.append(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.append(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBaseTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBaseTest.java
@@ -91,10 +91,10 @@ public abstract class PipelinedClientBaseTest {
   protected String rowKey2 = "rk2-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
   protected String indexKey1 = "ik1-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
   protected String indexKey2 = "ik2-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
-  protected String routeKeyCh = "CH-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
-  protected String routeKeyHyd = "HYD-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
-  protected Optional<String> routeKeyChOptional = Optional.of(routeKeyCh);
-  protected Optional<String> routeKeyHydOptional = Optional.of(routeKeyHyd);
+  protected String routeMetaCh = "CH-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
+  protected String routeMetaHyd = "HYD-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
+  protected Optional<String> routeMetaChOptional = Optional.of(routeMetaCh);
+  protected Optional<String> routeMetaHydOptional = Optional.of(routeMetaHyd);
   protected String cf1 = "cf1-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
   protected String cf2 = "cf2-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
   protected String cq1 = "cq1-" + RandomStringUtils.randomAlphanumeric(10).toUpperCase();
@@ -158,7 +158,7 @@ public abstract class PipelinedClientBaseTest {
           new StoreDataBuilder(FULL_TABLE_NAME).withRowKey(iRowKey.getBytes()).addColumn(cf1, cq1, qv1.getBytes())
               .build();
       when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(CompletableFuture.completedFuture(null));
-      intentData = Optional.of(new YakIntentWriteRequest<String, HystrixSettings>(intentStoreData, routeKeyHydOptional,
+      intentData = Optional.of(new YakIntentWriteRequest<String, HystrixSettings>(intentStoreData, routeMetaHydOptional,
           Optional.of(new HystrixSettings(storeSettings))));
     }
   }
@@ -222,32 +222,32 @@ public abstract class PipelinedClientBaseTest {
   }
 
   protected HotRouter nullRoute = new HotRouter<MasterSlaveReplicaSet, String>() {
-    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeKey)
+    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeMeta)
         throws NoSiteAvailableToHandleException {
       return null;
     }
   };
 
   protected HotRouter nullValuesRoute = new HotRouter<MasterSlaveReplicaSet, String>() {
-    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeKey)
+    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeMeta)
         throws NoSiteAvailableToHandleException {
       return new MasterSlaveReplicaSet(null, null);
     }
   };
 
   protected HotRouter localPreferredRouter = new HotRouter<MasterSlaveReplicaSet, String>() {
-    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeKey)
+    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeMeta)
         throws NoSiteAvailableToHandleException {
       return new MasterSlaveReplicaSet(Region1SiteA, Arrays.asList(Region2SiteA, Region1SiteB));
     }
   };
 
   protected HotRouter router = new HotRouter<MasterSlaveReplicaSet, String>() {
-    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeKey)
+    @Override public MasterSlaveReplicaSet getReplicaSet(Optional<String> routeMeta)
         throws NoSiteAvailableToHandleException {
       MasterSlaveReplicaSet replicaSet;
-      if (routeKey.isPresent()) {
-        String key = routeKey.get();
+      if (routeMeta.isPresent()) {
+        String key = routeMeta.get();
         if (key.startsWith("CH")) {
           replicaSet = new MasterSlaveReplicaSet(Region1SiteA, Arrays.asList(Region1SiteB, Region2SiteA));
         } else if (key.startsWith("HYD")) {

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchDeleteTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchDeleteTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.DeleteData;
 import com.flipkart.yak.models.DeleteDataBuilder;
@@ -58,7 +57,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.delete(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -76,7 +75,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
     PipelinedResponse<List<StoreOperationResponse<Void>>> response =
-        syncStore.delete(dataList, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.delete(dataList, routeMetaChOptional, intentData, hystrixSettings);
 
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resp.getValue() == null));
@@ -92,7 +91,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.delete(dataList, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -113,7 +112,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFailureFuture);
-    store.delete(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     try {
       future.get();
@@ -132,7 +131,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region2SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.delete(dataList, routeKeyHydOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaHydOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -152,7 +151,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture respFailureFuture = new CompletableFuture();
     respFailureFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
-    store.delete(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -172,7 +171,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     respFailureFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
     PipelinedResponse<List<StoreOperationResponse<Void>>> response =
-        syncStore.delete(dataList, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.delete(dataList, routeMetaChOptional, intentData, hystrixSettings);
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resp.getValue() == null));
       assertTrue("Should throw exception", (resp.getError() != null));
@@ -214,7 +213,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteBClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.delete(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -240,7 +239,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteBClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.delete(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -267,7 +266,7 @@ public class PipelinedClientBatchDeleteTest extends PipelinedClientBaseTest {
     when(region1SiteBClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region2SiteAClient.delete(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.delete(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.delete(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchGetTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchGetTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.Cell;
 import com.flipkart.yak.models.ColumnsMap;
@@ -77,7 +76,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
         resultsMap.stream().map(resultMap -> CompletableFuture.completedFuture(resultMap))
             .collect(Collectors.toList()));
 
-    store.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resultsMap.contains(resp.getValue())));
@@ -95,7 +94,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
             .collect(Collectors.toList()));
 
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response =
-        syncStore.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings);
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resultsMap.contains(resp.getValue())));
       assertTrue("Should not throw exception", (resp.getError() == null));
@@ -111,7 +110,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
         resultsMap.stream().map(resultMap -> CompletableFuture.completedFuture(resultMap))
             .collect(Collectors.toList()));
 
-    store.get(rows, routeKeyHydOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.get(rows, routeMetaHydOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should not have response", (resultsMap.contains(resp.getValue())));
@@ -131,7 +130,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
 
     when(region1SiteAClient.get(eq(rows)))
         .thenReturn(resultsMap.stream().map(resultMap -> respFuture).collect(Collectors.toList()));
-    store.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resp.getValue() == null));
@@ -151,7 +150,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.get(eq(rows)))
         .thenReturn(resultsMap.stream().map(resultMap -> respFuture).collect(Collectors.toList()));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response =
-        syncStore.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings);
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resp.getValue() == null));
       assertTrue("Should not throw exception", (resp.getError() != null));
@@ -194,7 +193,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
         resultsMap.stream().map(resultMap -> CompletableFuture.completedFuture(resultMap))
             .collect(Collectors.toList()));
 
-    store.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resultsMap.contains(resp.getValue())));
@@ -221,7 +220,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
         resultsMap.stream().map(resultMap -> CompletableFuture.completedFuture(resultMap))
             .collect(Collectors.toList()));
 
-    store.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resultsMap.contains(resp.getValue())));
@@ -249,7 +248,7 @@ public class PipelinedClientBatchGetTest extends PipelinedClientBaseTest {
         resultsMap.stream().map(resultMap -> CompletableFuture.completedFuture(resultMap))
             .collect(Collectors.toList()));
 
-    store.get(rows, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.get(rows, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
     PipelinedResponse<List<StoreOperationResponse<ResultMap>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resultsMap.contains(resp.getValue())));

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchPutTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchPutTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.StoreData;
 import com.flipkart.yak.models.StoreDataBuilder;
@@ -62,7 +61,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.put(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -81,7 +80,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response =
-        syncStore.put(dataList, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.put(dataList, routeMetaChOptional, intentData, hystrixSettings);
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resp.getValue() == null));
       assertTrue("Should not throw exception", (resp.getError() == null));
@@ -96,7 +95,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.put(dataList, routeKeyChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -117,7 +116,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFailureFuture);
-    store.put(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     try {
       future.get();
@@ -136,7 +135,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region2SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.put(dataList, routeKeyHydOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaHydOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -156,7 +155,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     CompletableFuture respFailureFuture = new CompletableFuture();
     respFailureFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
-    store.put(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -177,7 +176,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response =
-        syncStore.put(dataList, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.put(dataList, routeMetaChOptional, intentData, hystrixSettings);
     response.getOperationResponse().stream().forEachOrdered(resp -> {
       assertTrue("Should have null response", (resp.getValue() == null));
       assertTrue("Should throw exception", (resp.getError() != null));
@@ -219,7 +218,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> future = new CompletableFuture<>();
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteBClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.put(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -245,7 +244,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region1SiteBClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.put(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {
@@ -272,7 +271,7 @@ public class PipelinedClientBatchPutTest extends PipelinedClientBaseTest {
     when(region1SiteBClient.put(eq(dataList))).thenReturn(Arrays.asList(respFailureFuture, respFailureFuture));
     CompletableFuture<Void> respFuture = CompletableFuture.completedFuture(null);
     when(region2SiteAClient.put(eq(dataList))).thenReturn(Arrays.asList(respFuture, respFuture));
-    store.put(dataList, routeKeyChOptional, intentData, hystrixSettings, responsesHandler(future));
+    store.put(dataList, routeMetaChOptional, intentData, hystrixSettings, responsesHandler(future));
 
     PipelinedResponse<List<StoreOperationResponse<Void>>> response = future.get();
     response.getOperationResponse().stream().forEachOrdered(resp -> {

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientCheckDeleteTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientCheckDeleteTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.CheckAndDeleteData;
 import com.flipkart.yak.models.DeleteDataBuilder;
@@ -56,7 +55,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
   @Test public void testCheckDeleteToRegion1SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -73,7 +72,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
           throws ExecutionException, InterruptedException, TimeoutException {
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
     PipelinedResponse<StoreOperationResponse<Boolean>> response =
-        syncStore.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -88,7 +87,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
   @Test public void testCheckDeleteToRegion1SiteAWithNoIntent() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndDelete(deleteData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -108,7 +107,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFuture);
-    store.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     try {
       future.get();
       assertTrue("Should have thrown exception", false || (!runWithIntent));
@@ -125,7 +124,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
   @Test public void testCheckDeleteToRegion2SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region2SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndDelete(deleteData, routeKeyHydOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaHydOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -145,7 +144,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(respFuture);
-    store.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
@@ -164,7 +163,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(respFuture);
     PipelinedResponse<StoreOperationResponse<Boolean>> response =
-        syncStore.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings);
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
     assertTrue("Should throw exception",
@@ -202,7 +201,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteBClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -228,7 +227,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException("Failed"));
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(respFuture);
     when(region1SiteBClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -255,7 +254,7 @@ public class PipelinedClientCheckDeleteTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(respFuture);
     when(region1SiteBClient.checkAndDelete(eq(deleteData))).thenReturn(respFuture);
     when(region2SiteAClient.checkAndDelete(eq(deleteData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndDelete(deleteData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndDelete(deleteData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientCheckPutTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientCheckPutTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.CheckAndStoreData;
 import com.flipkart.yak.models.StoreDataBuilder;
@@ -57,7 +56,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
   @Test public void testCheckPutToRegion1SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -75,7 +74,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
     PipelinedResponse<StoreOperationResponse<Boolean>> response =
-        syncStore.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -91,7 +90,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
     store
-        .checkAndPut(checkAndStoreData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+        .checkAndPut(checkAndStoreData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -111,7 +110,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFuture);
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     try {
       future.get();
       assertTrue("Should have thrown exception", false || (!runWithIntent));
@@ -128,7 +127,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
   @Test public void testCheckPutToRegion2SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region2SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndPut(checkAndStoreData, routeKeyHydOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaHydOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -148,7 +147,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(respFuture);
-    store.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
@@ -168,7 +167,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(respFuture);
     PipelinedResponse<StoreOperationResponse<Boolean>> response =
-        syncStore.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings);
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
@@ -207,7 +206,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     store = generatePipelinedStore(storeConfig, storeRoute, registry, intentStore);
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> future = new CompletableFuture<>();
     when(region1SiteBClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -233,7 +232,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException("Failed"));
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(respFuture);
     when(region1SiteBClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -259,7 +258,7 @@ public class PipelinedClientCheckPutTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(respFuture);
     when(region1SiteBClient.checkAndPut(eq(checkAndStoreData))).thenReturn(respFuture);
     when(region2SiteAClient.checkAndPut(eq(checkAndStoreData))).thenReturn(CompletableFuture.completedFuture(true));
-    store.checkAndPut(checkAndStoreData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.checkAndPut(checkAndStoreData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Boolean>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientGetByIndexTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientGetByIndexTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.Cell;
 import com.flipkart.yak.models.ColumnsMap;
@@ -74,7 +73,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
       throws ExecutionException, InterruptedException, StoreException, IOException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> future = new CompletableFuture<>();
     when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(CompletableFuture.completedFuture(columns));
-    store.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -87,7 +86,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> futureCell = new CompletableFuture<>();
     when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(cells));
-    store.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell = futureCell.get();
     if (responseCell.getOperationResponse().getError() != null) {
       throw new ExecutionException(responseCell.getOperationResponse().getError());
@@ -103,7 +102,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
       throws ExecutionException, InterruptedException, TimeoutException {
     when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(CompletableFuture.completedFuture(columns));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response =
-        syncStore.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -115,7 +114,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
 
     when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(cells));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell =
-        syncStore.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings);
     if (responseCell.getOperationResponse().getError() != null) {
       throw new ExecutionException(responseCell.getOperationResponse().getError());
     }
@@ -130,7 +129,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> future = new CompletableFuture<>();
     when(region2SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(CompletableFuture.completedFuture(columns));
     store
-        .getByIndex(columnsMapByIndex, routeKeyHydOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+        .getByIndex(columnsMapByIndex, routeMetaHydOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -144,7 +143,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> futureCell = new CompletableFuture<>();
     when(region2SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(cells));
-    store.getByIndex(cellByIndex, routeKeyHydOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
+    store.getByIndex(cellByIndex, routeMetaHydOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell = futureCell.get();
     if (responseCell.getOperationResponse().getError() != null) {
       throw new ExecutionException(responseCell.getOperationResponse().getError());
@@ -164,7 +163,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(respFuture);
-    store.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response = future.get();
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
@@ -176,7 +175,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> futureCell = new CompletableFuture<>();
     when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(respFuture);
-    store.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell = futureCell.get();
     assertTrue("Should have null response", (responseCell.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (responseCell.getOperationResponse().getError() != null));
@@ -194,7 +193,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(respFuture);
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response =
-        syncStore.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings);
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
     assertTrue("Should throw exception",
@@ -205,7 +204,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
 
     when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(respFuture);
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell =
-        syncStore.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings);
     assertTrue("Should have null response", (responseCell.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (responseCell.getOperationResponse().getError() != null));
     assertTrue("Should throw exception",
@@ -256,7 +255,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     store = generatePipelinedStore(storeConfig, storeRoute, registry, intentStore);
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> future = new CompletableFuture<>();
     when(region1SiteBClient.getByIndex(eq(columnsMapByIndex))).thenReturn(CompletableFuture.completedFuture(columns));
-    store.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -270,7 +269,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> futureCell = new CompletableFuture<>();
     when(region1SiteBClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(cells));
-    store.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell = futureCell.get();
     if (responseCell.getOperationResponse().getError() != null) {
       throw new ExecutionException(responseCell.getOperationResponse().getError());
@@ -296,7 +295,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> future = new CompletableFuture<>();
     when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(respFuture);
     when(region1SiteBClient.getByIndex(eq(columnsMapByIndex))).thenReturn(CompletableFuture.completedFuture(columns));
-    store.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -311,7 +310,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> futureCell = new CompletableFuture<>();
     when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(respFuture);
     when(region1SiteBClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(cells));
-    store.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell = futureCell.get();
     if (responseCell.getOperationResponse().getError() != null) {
       throw new ExecutionException(responseCell.getOperationResponse().getError());
@@ -338,7 +337,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(respFuture);
     when(region1SiteBClient.getByIndex(eq(columnsMapByIndex))).thenReturn(respFuture);
     when(region2SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(CompletableFuture.completedFuture(columns));
-    store.getByIndex(columnsMapByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -354,7 +353,7 @@ public class PipelinedClientGetByIndexTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(respFuture);
     when(region1SiteBClient.getByIndex(eq(cellByIndex))).thenReturn(respFuture);
     when(region2SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(cells));
-    store.getByIndex(cellByIndex, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(futureCell));
     PipelinedResponse<StoreOperationResponse<List<Cell>>> responseCell = futureCell.get();
     if (responseCell.getOperationResponse().getError() != null) {
       throw new ExecutionException(responseCell.getOperationResponse().getError());

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientGetTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientGetTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.GetColumnMap;
 import com.flipkart.yak.models.GetDataBuilder;
@@ -58,7 +57,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteAClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -75,7 +74,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     GetColumnMap row = new GetDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).buildForColFamily(cf1);
     when(region1SiteAClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -92,7 +91,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response =
-        syncStore.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -107,7 +106,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region2SiteAClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyHydOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaHydOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -127,7 +126,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.get(eq(row))).thenReturn(respFuture);
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
@@ -146,7 +145,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.get(eq(row))).thenReturn(respFuture);
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response =
-        syncStore.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings);
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
     assertTrue("Should throw exception",
@@ -184,7 +183,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteBClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -209,7 +208,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.get(eq(row))).thenReturn(respFuture);
     when(region1SiteBClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -235,7 +234,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     when(region1SiteBClient.get(eq(row))).thenReturn(respFuture);
     when(region2SiteAClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -262,7 +261,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.get(eq(row))).thenReturn(respFuture);
     when(region1SiteBClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -286,7 +285,7 @@ public class PipelinedClientGetTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region2SiteAClient.get(eq(row))).thenReturn(CompletableFuture.completedFuture(resultMap));
 
-    store.get(row, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.get(row, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientIncrementTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientIncrementTest.java
@@ -64,7 +64,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
 
-    store.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
@@ -82,7 +82,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     throws ExecutionException, InterruptedException, TimeoutException {
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response =
-      syncStore.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings);
+      syncStore.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings);
 
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -99,7 +99,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
   public void testIncrementToRegion1SiteAWithNoIntent() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
-    store.increment(incrementData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -121,7 +121,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFuture);
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
 
-    store.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
 
     try {
       future.get();
@@ -140,7 +140,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
   public void testIncrementToRegion2SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region2SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
-    store.increment(incrementData, routeKeyHydOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaHydOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -161,7 +161,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(respFuture);
-    store.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
@@ -183,7 +183,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(respFuture);
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response =
-      syncStore.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings);
+      syncStore.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings);
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should not throw exception", (response.getOperationResponse().getError() != null));
@@ -224,7 +224,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     store = generatePipelinedStore(storeConfig, storeRoute, registry, intentStore);
     CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> future = new CompletableFuture<>();
     when(region1SiteBClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
-    store.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -251,7 +251,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.increment(eq(incrementData))).thenReturn(respFuture);
     when(region1SiteBClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
 
-    store.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
@@ -280,7 +280,7 @@ public class PipelinedClientIncrementTest extends PipelinedClientBaseTest {
     when(region1SiteBClient.increment(eq(incrementData))).thenReturn(respFuture);
     when(region2SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(result));
 
-    store.increment(incrementData, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.increment(incrementData, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
 
     PipelinedResponse<StoreOperationResponse<ResultMap>> response = future.get();
     if (response.getOperationResponse().getError() != null) {

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientOtherTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientOtherTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedClientInitializationException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.GetDataBuilder;
 import com.flipkart.yak.models.GetRow;
@@ -131,7 +130,7 @@ public class PipelinedClientOtherTest extends PipelinedClientBaseTest {
       return null;
     });
     when(region1SiteAClient.put(eq(data))).thenReturn(responseFuture);
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     try {
       future.get();
       assertTrue("Should have thrown exception", true);

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientPutTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientPutTest.java
@@ -7,7 +7,6 @@ import com.flipkart.yak.models.StoreData;
 import com.flipkart.yak.models.StoreDataBuilder;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import java.io.IOException;
 import java.util.Arrays;
@@ -54,7 +53,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
   @Test public void testPutToRegion1SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> future = new CompletableFuture<>();
     when(region1SiteAClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -71,7 +70,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
           throws ExecutionException, InterruptedException, TimeoutException {
     when(region1SiteAClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
     PipelinedResponse<StoreOperationResponse<Void>> response =
-        syncStore.put(data, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.put(data, routeMetaChOptional, intentData, hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -86,7 +85,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
   @Test public void testPutToRegion1SiteAWithNoIntent() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> future = new CompletableFuture<>();
     when(region1SiteAClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -106,7 +105,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region2SiteAClient.put(eq(intentStoreData))).thenReturn(respFuture);
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     try {
       future.get();
       assertTrue("Should have thrown exception", false || (!runWithIntent));
@@ -122,7 +121,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
   @Test public void testPutToRegion2SiteA() throws ExecutionException, InterruptedException {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> future = new CompletableFuture<>();
     when(region2SiteAClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyHydOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaHydOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -142,7 +141,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     CompletableFuture respFuture = new CompletableFuture();
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.put(eq(data))).thenReturn(respFuture);
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should throw exception", (response.getOperationResponse().getError() != null));
@@ -161,7 +160,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.put(eq(data))).thenReturn(respFuture);
     PipelinedResponse<StoreOperationResponse<Void>> response =
-        syncStore.put(data, routeKeyChOptional, intentData, hystrixSettings);
+        syncStore.put(data, routeMetaChOptional, intentData, hystrixSettings);
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should throw exception", (response.getOperationResponse().getError() != null));
     assertTrue("Should throw exception",
@@ -198,7 +197,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     store = generatePipelinedStore(storeConfig, storeRoute, registry, intentStore);
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> future = new CompletableFuture<>();
     when(region1SiteBClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -223,7 +222,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException("Failed"));
     when(region1SiteAClient.put(eq(data))).thenReturn(respFuture);
     when(region1SiteBClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -250,7 +249,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.put(eq(data))).thenReturn(respFuture);
     when(region1SiteBClient.put(eq(data))).thenReturn(respFuture);
     when(region2SiteAClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -276,7 +275,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException("Exception"));
     when(region1SiteAClient.put(eq(data))).thenReturn(respFuture);
     when(region1SiteBClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -299,7 +298,7 @@ public class PipelinedClientPutTest extends PipelinedClientBaseTest {
 
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> future = new CompletableFuture<>();
     when(region2SiteAClient.put(eq(data))).thenReturn(CompletableFuture.completedFuture(null));
-    store.put(data, routeKeyChOptional, intentData, hystrixSettings, responseHandler(future));
+    store.put(data, routeMetaChOptional, intentData, hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Void>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientScanTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientScanTest.java
@@ -5,7 +5,6 @@ import com.flipkart.yak.client.exceptions.StoreException;
 import com.flipkart.yak.client.pipelined.exceptions.NoSiteAvailableToHandleException;
 import com.flipkart.yak.client.pipelined.exceptions.PipelinedStoreException;
 import com.flipkart.yak.client.pipelined.models.*;
-import com.flipkart.yak.client.pipelined.models.DataCenter;
 import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.ResultMap;
 import com.flipkart.yak.models.ScanData;
@@ -61,7 +60,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> future = new CompletableFuture<>();
     when(region1SiteAClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -80,7 +79,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response =
-        syncStore.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings);
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
     }
@@ -96,7 +95,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> future = new CompletableFuture<>();
     when(region2SiteAClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyHydOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaHydOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -117,7 +116,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     respFuture.completeExceptionally(new PipelinedStoreException(errorMessage));
     when(region1SiteAClient.scan(scanData)).thenReturn(respFuture);
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
@@ -138,7 +137,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.scan(scanData)).thenReturn(respFuture);
 
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response =
-        syncStore.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings);
+        syncStore.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings);
 
     assertTrue("Should have null response", (response.getOperationResponse().getValue() == null));
     assertTrue("Should throw exception", (response.getOperationResponse().getError() != null));
@@ -178,7 +177,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> future = new CompletableFuture<>();
     when(region1SiteBClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -204,7 +203,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.scan(scanData)).thenReturn(respFuture);
     when(region1SiteBClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -231,7 +230,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     when(region1SiteBClient.scan(scanData)).thenReturn(respFuture);
     when(region2SiteAClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -257,7 +256,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     when(region1SiteAClient.scan(scanData)).thenReturn(respFuture);
     when(region1SiteBClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());
@@ -280,7 +279,7 @@ public class PipelinedClientScanTest extends PipelinedClientBaseTest {
     CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> future = new CompletableFuture<>();
     when(region2SiteAClient.scan(scanData)).thenReturn(CompletableFuture.completedFuture(resultMaps));
 
-    store.scan(scanData, routeKeyChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(future));
     PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> response = future.get();
     if (response.getOperationResponse().getError() != null) {
       throw new ExecutionException(response.getOperationResponse().getError());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated all method, parameter, and variable names from "routeKey" to "routeMeta" throughout the codebase and tests for improved naming consistency.
  * Adjusted related documentation and comments to reflect the new naming.
* **Tests**
  * Updated all test cases to use the new "routeMeta" naming convention in method calls and variables.
  * Removed unused imports in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->