### PR TITLE
Add optional executor queue capacity for pipelined store thread pool

### DIFF
--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -96,8 +96,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
    *
    * @param executorQueueCapacity optional queue capacity; empty for unbounded
    * @return a blocking queue for executor tasks
+   * @throws ConfigValidationFailedException if capacity is present but not positive
    */
-  private static LinkedBlockingQueue<Runnable> getWorkQueue(Optional<Integer> executorQueueCapacity) {
+  private static LinkedBlockingQueue<Runnable> getWorkQueue(Optional<Integer> executorQueueCapacity) throws ConfigValidationFailedException {
+    if (executorQueueCapacity.isPresent() && executorQueueCapacity.get() <= 0) {
+      throw new ConfigValidationFailedException(
+              "executorQueueCapacity must be positive, got: " + executorQueueCapacity.get());
+    }
     return executorQueueCapacity
             .map(capacity -> new LinkedBlockingQueue<Runnable>(capacity))
             .orElseGet(LinkedBlockingQueue::new);

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -78,7 +78,7 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
     this.publisher.init();
     this.executor =
         new ThreadPoolExecutor(pipelineConfig.getPoolSize(), pipelineConfig.getPoolSize(), 0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<Runnable>(), new ThreadFactory() {
+            getWorkQueue(pipelineConfig.getExecutorQueueCapacity()), new ThreadFactory() {
           private AtomicInteger counter = new AtomicInteger(0);
 
           @Override public Thread newThread(Runnable r) {
@@ -88,6 +88,19 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
 
     MultiRegionConfigValidator.validate(pipelineConfig.getMultiRegionStoreConfig());
     _createClients(this.pipelineConfig);
+  }
+
+  /**
+   * Returns a work queue for the thread pool: bounded to the given capacity when present,
+   * otherwise unbounded.
+   *
+   * @param executorQueueCapacity optional queue capacity; empty for unbounded
+   * @return a blocking queue for executor tasks
+   */
+  private static LinkedBlockingQueue<Runnable> getWorkQueue(Optional<Integer> executorQueueCapacity) {
+    return executorQueueCapacity
+            .map(capacity -> new LinkedBlockingQueue<Runnable>(capacity))
+            .orElseGet(LinkedBlockingQueue::new);
   }
 
   private SiteConfig mergeDefaultConfigWithSiteConfig(SiteConfig siteConfig, SiteConfig defaultConfig) {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -91,15 +91,16 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
   }
 
   /**
-   * Returns a work queue for the thread pool: bounded to the given capacity when present,
-   * otherwise unbounded.
+   * Returns a work queue for the thread pool: unbounded when capacity is 0, bounded to the given capacity when positive.
    *
-   * @param queueCapacity int queue capacity;
+   * @param queueCapacity queue capacity; 0 for unbounded, positive for bounded
    * @return a blocking queue for executor tasks
-   * if the capacity is 0 (default value) returns an unbounded queue else returns a bounded queue with provided capacity.
+   * @throws IllegalArgumentException if queueCapacity is negative
    */
   private static LinkedBlockingQueue<Runnable> getWorkQueue(int queueCapacity) throws ConfigValidationFailedException {
-    if(queueCapacity == 0) {
+    if(queueCapacity < 0 ){
+      throw new IllegalArgumentException("executorQueueCapacity must be positive, got: " + queueCapacity);
+    } else if( queueCapacity == 0 ) {
       return new LinkedBlockingQueue<Runnable>();
     } else {
       return new LinkedBlockingQueue<Runnable>(queueCapacity);

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -312,13 +312,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
           PipelinedClientMetricsPublisher.INCREMENT_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-          new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+          new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
           error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.INCREMENT_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.INCREMENT_NO_SITES);
@@ -345,13 +345,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.PUT_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-                new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+                new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.PUT_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.PUT_NO_SITES);
@@ -376,13 +376,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
                 PipelinedClientMetricsPublisher.BATCH_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-            new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+            new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_NO_SITES);
@@ -409,14 +409,14 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.BATCH_PUT_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((results, error) -> {
-        boolean isStale =
-            !results.stream().filter(result -> !(sites.get(0).equals(result.getSite()))).collect(Collectors.toList())
+      future.whenComplete((results, error) -> {
+        boolean isStale = results != null
+            && !results.stream().filter(result -> !(sites.get(0).equals(result.getSite()))).collect(Collectors.toList())
                 .isEmpty();
         handler.accept(new PipelinedResponse<>(results, isStale), error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_PUT_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_PUT_NO_SITES);
@@ -443,13 +443,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.CAS_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-                new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+                new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.CAS_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.CAS_NO_SITES);
@@ -476,13 +476,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.APPEND_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-                new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+                new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.APPEND_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.APPEND_NO_SITES);
@@ -509,14 +509,14 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.BATCH_DELETE_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((results, error) -> {
-        boolean isStale =
-            !results.stream().filter(result -> !(sites.get(0).equals(result.getSite()))).collect(Collectors.toList())
+      future.whenComplete((results, error) -> {
+        boolean isStale = results != null
+            && !results.stream().filter(result -> !(sites.get(0).equals(result.getSite()))).collect(Collectors.toList())
                 .isEmpty();
         handler.accept(new PipelinedResponse<>(results, isStale), error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_DELETE_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_DELETE_NO_SITES);
@@ -542,13 +542,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
         future = future.thenComposeAsync(value -> runClientOperation(data, site, value, CHECK_DELETE_METHOD_NAME,
             PipelinedClientMetricsPublisher.CHECK_DELETE_FALLBACK), executor);
       }
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-                new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+                new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.CHECK_DELETE_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.CHECK_DELETE_NO_SITES);
@@ -573,12 +573,12 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.SCAN_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(new PipelinedResponse<>(result,
-                !(sites.get(0).equals(result.getSite()))), error);
+                result != null && !(sites.get(0).equals(result.getSite()))), error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.SCAN_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.SCAN_NO_SITES);
@@ -605,13 +605,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.GET_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-                new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+                new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.GET_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.GET_NO_SITES);
@@ -638,14 +638,14 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.BATCH_GET_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((results, error) -> {
-        boolean isStale =
-            !results.stream().filter(result -> !(sites.get(0).equals(result.getSite()))).collect(Collectors.toList())
+      future.whenComplete((results, error) -> {
+        boolean isStale = results != null
+            && !results.stream().filter(result -> !(sites.get(0).equals(result.getSite()))).collect(Collectors.toList())
                 .isEmpty();
         handler.accept(new PipelinedResponse<>(results, isStale), error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_GET_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.BATCH_GET_NO_SITES);
@@ -672,12 +672,12 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.INDEX_GET_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(new PipelinedResponse<>(result,
-                !(sites.get(0).equals(result.getSite()))), error);
+                result != null && !(sites.get(0).equals(result.getSite()))), error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.INDEX_GET_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.INDEX_GET_NO_SITES);
@@ -704,13 +704,13 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
             PipelinedClientMetricsPublisher.INDEX_GET_FALLBACK), executor);
       }
 
-      future.whenCompleteAsync((result, error) -> {
+      future.whenComplete((result, error) -> {
         handler.accept(
-                new PipelinedResponse<>(result, !(sites.get(0).equals(result.getSite()))),
+                new PipelinedResponse<>(result, result != null && !(sites.get(0).equals(result.getSite()))),
             error);
         publisher.incrementMetric(PipelinedClientMetricsPublisher.INDEX_GET_COMPLETE);
         timer.close();
-      }, executor);
+      });
     } catch (NoSiteAvailableToHandleException | PipelinedStoreDataCorruptException ex) {
       handler.accept(null, ex);
       publisher.incrementMetric(PipelinedClientMetricsPublisher.INDEX_GET_NO_SITES);

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -97,9 +97,9 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
    * @return a blocking queue for executor tasks
    * @throws IllegalArgumentException if queueCapacity is negative
    */
-  private static LinkedBlockingQueue<Runnable> getWorkQueue(int queueCapacity) throws ConfigValidationFailedException {
+  private static LinkedBlockingQueue<Runnable> getWorkQueue(int queueCapacity) {
     if(queueCapacity < 0 ){
-      throw new IllegalArgumentException("executorQueueCapacity must be positive, got: " + queueCapacity);
+      throw new IllegalArgumentException("executorQueueCapacity must be positive or 0, got: " + queueCapacity);
     } else if( queueCapacity == 0 ) {
       return new LinkedBlockingQueue<Runnable>();
     } else {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -97,9 +97,9 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
    * @return a blocking queue for executor tasks
    * @throws IllegalArgumentException if queueCapacity is negative
    */
-  private static LinkedBlockingQueue<Runnable> getWorkQueue(int queueCapacity) {
+  private static LinkedBlockingQueue<Runnable> getWorkQueue(int queueCapacity) throws ConfigValidationFailedException {
     if(queueCapacity < 0 ){
-      throw new IllegalArgumentException("executorQueueCapacity must be positive or 0, got: " + queueCapacity);
+      throw new ConfigValidationFailedException("executorQueueCapacity must be positive or 0, got: " + queueCapacity);
     } else if( queueCapacity == 0 ) {
       return new LinkedBlockingQueue<Runnable>();
     } else {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImpl.java
@@ -94,18 +94,16 @@ public class MasterSlaveYakPipelinedStoreImpl<T, U extends IntentWriteRequest, V
    * Returns a work queue for the thread pool: bounded to the given capacity when present,
    * otherwise unbounded.
    *
-   * @param executorQueueCapacity optional queue capacity; empty for unbounded
+   * @param queueCapacity int queue capacity;
    * @return a blocking queue for executor tasks
-   * @throws ConfigValidationFailedException if capacity is present but not positive
+   * if the capacity is 0 (default value) returns an unbounded queue else returns a bounded queue with provided capacity.
    */
-  private static LinkedBlockingQueue<Runnable> getWorkQueue(Optional<Integer> executorQueueCapacity) throws ConfigValidationFailedException {
-    if (executorQueueCapacity.isPresent() && executorQueueCapacity.get() <= 0) {
-      throw new ConfigValidationFailedException(
-              "executorQueueCapacity must be positive, got: " + executorQueueCapacity.get());
+  private static LinkedBlockingQueue<Runnable> getWorkQueue(int queueCapacity) throws ConfigValidationFailedException {
+    if(queueCapacity == 0) {
+      return new LinkedBlockingQueue<Runnable>();
+    } else {
+      return new LinkedBlockingQueue<Runnable>(queueCapacity);
     }
-    return executorQueueCapacity
-            .map(capacity -> new LinkedBlockingQueue<Runnable>(capacity))
-            .orElseGet(LinkedBlockingQueue::new);
   }
 
   private SiteConfig mergeDefaultConfigWithSiteConfig(SiteConfig siteConfig, SiteConfig defaultConfig) {

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/exceptions/ConfigValidationFailedException.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/exceptions/ConfigValidationFailedException.java
@@ -1,6 +1,11 @@
 package com.flipkart.yak.client.pipelined.exceptions;
 
 public class ConfigValidationFailedException extends Exception {
+
+  public ConfigValidationFailedException(String message) {
+    super(message);
+  }
+
   public ConfigValidationFailedException(Throwable e) {
     super(e);
   }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/exceptions/ConfigValidationFailedException.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/exceptions/ConfigValidationFailedException.java
@@ -1,11 +1,6 @@
 package com.flipkart.yak.client.pipelined.exceptions;
 
 public class ConfigValidationFailedException extends Exception {
-
-  public ConfigValidationFailedException(String message) {
-    super(message);
-  }
-
   public ConfigValidationFailedException(Throwable e) {
     super(e);
   }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/PipelineConfig.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/PipelineConfig.java
@@ -18,6 +18,8 @@ public class PipelineConfig {
   private final String name;
   private int siteBootstrapRetryCount = 3;
   private long siteBootstrapRetryDelayInMillis = 3000;
+  /** Optional bound for the thread-pool work queue; empty means unbounded. */
+  private Optional<Integer> executorQueueCapacity = Optional.empty();
 
   public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, int poolSize, int siteBootstrapTimeoutInSeconds,
                         String name) {
@@ -45,6 +47,20 @@ public class PipelineConfig {
     this.siteBootstrapRetryDelayInMillis = siteBootstrapRetryDelayInMillis;
   }
 
+  public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, Optional<Map<String, KeyDistributor>> keyDistributorMap,
+                        int siteBootstrapTimeoutInSeconds, int poolSize, String name,
+                        int siteBootstrapRetryCount, long siteBootstrapRetryDelayInMillis, Integer executorQueueCapacity) {
+    this.multiRegionStoreConfig = multiRegionStoreConfig;
+    this.keyDistributorMap = keyDistributorMap;
+    this.siteBootstrapTimeoutInSeconds = siteBootstrapTimeoutInSeconds;
+    this.poolSize = poolSize;
+    this.name = name;
+    this.siteBootstrapRetryCount = siteBootstrapRetryCount;
+    this.siteBootstrapRetryDelayInMillis = siteBootstrapRetryDelayInMillis;
+    this.executorQueueCapacity = Optional.ofNullable(executorQueueCapacity);
+  }
+
+
   public MultiRegionStoreConfig getMultiRegionStoreConfig() {
     return multiRegionStoreConfig;
   }
@@ -71,5 +87,9 @@ public class PipelineConfig {
 
   public long getSiteBootstrapRetryDelayInMillis() {
     return siteBootstrapRetryDelayInMillis;
+  }
+
+  public Optional<Integer> getExecutorQueueCapacity() {
+    return executorQueueCapacity;
   }
 }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/PipelineConfig.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/PipelineConfig.java
@@ -19,7 +19,7 @@ public class PipelineConfig {
   private int siteBootstrapRetryCount = 3;
   private long siteBootstrapRetryDelayInMillis = 3000;
   /** Optional bound for the thread-pool work queue; empty means unbounded. */
-  private Optional<Integer> executorQueueCapacity = Optional.empty();
+  private int executorQueueCapacity;
 
   public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, int poolSize, int siteBootstrapTimeoutInSeconds,
                         String name) {
@@ -47,17 +47,15 @@ public class PipelineConfig {
     this.siteBootstrapRetryDelayInMillis = siteBootstrapRetryDelayInMillis;
   }
 
-  public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, Optional<Map<String, KeyDistributor>> keyDistributorMap,
-                        int siteBootstrapTimeoutInSeconds, int poolSize, String name,
-                        int siteBootstrapRetryCount, long siteBootstrapRetryDelayInMillis, Integer executorQueueCapacity) {
-    this.multiRegionStoreConfig = multiRegionStoreConfig;
-    this.keyDistributorMap = keyDistributorMap;
-    this.siteBootstrapTimeoutInSeconds = siteBootstrapTimeoutInSeconds;
-    this.poolSize = poolSize;
-    this.name = name;
-    this.siteBootstrapRetryCount = siteBootstrapRetryCount;
-    this.siteBootstrapRetryDelayInMillis = siteBootstrapRetryDelayInMillis;
-    this.executorQueueCapacity = Optional.ofNullable(executorQueueCapacity);
+  public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, int siteBootstrapTimeoutInSeconds, int poolSize,
+                        String name, Optional<Map<String, KeyDistributor>> keyDistributorMap, int siteBootstrapRetryCount,
+                        long siteBootstrapRetryDelayInMillis, int executorQueueCapacity) {
+
+    this(multiRegionStoreConfig, siteBootstrapTimeoutInSeconds, poolSize, name, keyDistributorMap, siteBootstrapRetryCount, siteBootstrapRetryDelayInMillis);
+    if(executorQueueCapacity <=0) {
+      throw new IllegalArgumentException("executorQueueCapacity must be positive, got: " + executorQueueCapacity);
+    }
+    this.executorQueueCapacity = executorQueueCapacity;
   }
 
 
@@ -89,7 +87,7 @@ public class PipelineConfig {
     return siteBootstrapRetryDelayInMillis;
   }
 
-  public Optional<Integer> getExecutorQueueCapacity() {
+  public int getExecutorQueueCapacity() {
     return executorQueueCapacity;
   }
 }

--- a/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/PipelineConfig.java
+++ b/pipelined-client/src/main/java/com/flipkart/yak/client/pipelined/models/PipelineConfig.java
@@ -18,7 +18,9 @@ public class PipelineConfig {
   private final String name;
   private int siteBootstrapRetryCount = 3;
   private long siteBootstrapRetryDelayInMillis = 3000;
-  /** Optional bound for the thread-pool work queue; empty means unbounded. */
+  /**
+   * Capacity for the thread-pool work queue. Default is 0, which means an unbounded queue; a positive value sets a bounded capacity.
+   */
   private int executorQueueCapacity;
 
   public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, int poolSize, int siteBootstrapTimeoutInSeconds,
@@ -50,9 +52,8 @@ public class PipelineConfig {
   public PipelineConfig(MultiRegionStoreConfig multiRegionStoreConfig, int siteBootstrapTimeoutInSeconds, int poolSize,
                         String name, Optional<Map<String, KeyDistributor>> keyDistributorMap, int siteBootstrapRetryCount,
                         long siteBootstrapRetryDelayInMillis, int executorQueueCapacity) {
-
     this(multiRegionStoreConfig, siteBootstrapTimeoutInSeconds, poolSize, name, keyDistributorMap, siteBootstrapRetryCount, siteBootstrapRetryDelayInMillis);
-    if(executorQueueCapacity <=0) {
+    if (executorQueueCapacity <= 0) {
       throw new IllegalArgumentException("executorQueueCapacity must be positive, got: " + executorQueueCapacity);
     }
     this.executorQueueCapacity = executorQueueCapacity;

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImplTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImplTest.java
@@ -2,7 +2,11 @@ package com.flipkart.yak.client.pipelined;
 
 import com.flipkart.yak.client.pipelined.models.PipelineConfig;
 import com.flipkart.yak.client.pipelined.models.PipelinedResponse;
+import com.flipkart.yak.client.pipelined.models.ReadConsistency;
+import com.flipkart.yak.client.pipelined.models.Region;
 import com.flipkart.yak.client.pipelined.models.StoreOperationResponse;
+import com.flipkart.yak.client.pipelined.models.WriteConsistency;
+import com.flipkart.yak.client.pipelined.route.StoreRoute;
 import com.flipkart.yak.models.BatchData;
 import com.flipkart.yak.models.BatchDataBuilder;
 import com.flipkart.yak.models.Cell;
@@ -26,27 +30,31 @@ import com.flipkart.yak.models.StoreData;
 import com.flipkart.yak.models.StoreDataBuilder;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hbase.CompareOperator;
 import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runners.Parameterized;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -55,11 +63,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
 /**
- * Executor queue checks and, for each pipelined primitive, happy/failure paths through
- * {@code CompletableFuture.whenComplete} into the supplied {@code BiConsumer}.
+ * Tests for {@link MasterSlaveYakPipelinedStoreImpl}.
+ *
+ * <p>{@link PipelinedClientBaseTest} uses {@code @PowerMockRunnerDelegate(Parameterized.class)}; this
+ * class uses {@link BlockJUnit4ClassRunner} so IntelliJ can run single methods by name.
  */
-@PowerMockIgnore({ "java.lang.*", "javax.management.*" })
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(BlockJUnit4ClassRunner.class)
 public class MasterSlaveYakPipelinedStoreImplTest extends PipelinedClientBaseTest {
 
   private StoreData putData;
@@ -80,16 +94,6 @@ public class MasterSlaveYakPipelinedStoreImplTest extends PipelinedClientBaseTes
   private GetCellByIndex cellByIndex;
   private List<Cell> indexCellsResult;
   private StoreData appendData;
-
-  @Parameterized.Parameters(name = "hystrix={0}, intent={1}")
-  public static Collection<Object[]> parameters() {
-    return Arrays.asList(new Object[][] { { false, false } });
-  }
-
-  public MasterSlaveYakPipelinedStoreImplTest(boolean runWithHystrix, boolean runWithIntent) {
-    this.runWithHystrix = runWithHystrix;
-    this.runWithIntent = runWithIntent;
-  }
 
   @Before
   public void setupPrimitivePayloads() {
@@ -178,6 +182,73 @@ public class MasterSlaveYakPipelinedStoreImplTest extends PipelinedClientBaseTes
       LinkedBlockingQueue<?> q = (LinkedBlockingQueue<?>) ex.getQueue();
       assertEquals(capacity, q.remainingCapacity() + q.size());
       assertEquals(capacity, q.remainingCapacity());
+    } finally {
+      impl.shutdown();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void threeSitePutChainAfterTwoFailuresThirdSiteSucceedsCallbackOnStorePool() throws Exception {
+    StoreRoute preferredWriteRoute =
+        new StoreRoute(Region.REGION_1, ReadConsistency.PRIMARY_MANDATORY, WriteConsistency.PRIMARY_PREFERRED, router);
+    PipelineConfig cfg =
+        new PipelineConfig(buildConfig(), timeout, poolSize, STORE_NAME, Optional.of(keyDistributorMap),
+            siteBootstrapRetryCount, siteBootstrapRetryDelayInMillis);
+    @SuppressWarnings("rawtypes")
+    MasterSlaveYakPipelinedStoreImpl impl = new MasterSlaveYakPipelinedStoreImpl(cfg, preferredWriteRoute, registry);
+
+    Field exField = MasterSlaveYakPipelinedStoreImpl.class.getDeclaredField("executor");
+    exField.setAccessible(true);
+    ThreadPoolExecutor created = (ThreadPoolExecutor) exField.get(impl);
+    created.shutdownNow();
+    created.awaitTermination(5, TimeUnit.SECONDS);
+
+    AtomicInteger chainThreadIndex = new AtomicInteger();
+    ThreadFactory tf = r -> {
+      Thread t = new Thread(r, "three-site-chain-" + chainThreadIndex.getAndIncrement());
+      t.setDaemon(true);
+      return t;
+    };
+    ThreadPoolExecutor dual =
+        new ThreadPoolExecutor(2, 2, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), tf);
+    exField.set(impl, dual);
+
+    AtomicReference<String> lastSiteThread = new AtomicReference<>();
+    when(region1SiteAClient.put(eq(putData))).thenReturn(failedFuture(new RuntimeException("site1 fail")));
+    when(region1SiteBClient.put(eq(putData))).thenReturn(failedFuture(new RuntimeException("site2 fail")));
+    when(region2SiteAClient.put(eq(putData))).thenAnswer(invocation -> {
+      lastSiteThread.set(Thread.currentThread().getName());
+      return CompletableFuture.completedFuture(null);
+    });
+
+    AtomicReference<String> callbackThread = new AtomicReference<>();
+    CountDownLatch done = new CountDownLatch(1);
+    try {
+      impl.put(putData, routeMetaChOptional, Optional.empty(), hystrixSettings, (response, error) -> {
+        callbackThread.set(Thread.currentThread().getName());
+        assertNull(error);
+        assertNotNull(response);
+        PipelinedResponse<StoreOperationResponse<Void>> pr =
+            (PipelinedResponse<StoreOperationResponse<Void>>) response;
+        assertNotNull(pr.getOperationResponse());
+        assertNull(pr.getOperationResponse().getError());
+        assertEquals(Region2SiteA, pr.getOperationResponse().getSite());
+        done.countDown();
+      });
+
+      assertTrue(done.await(10, TimeUnit.SECONDS));
+      verify(region1SiteAClient, times(1)).put(putData);
+      verify(region1SiteBClient, times(1)).put(putData);
+      verify(region2SiteAClient, times(1)).put(putData);
+
+      String junitThread = Thread.currentThread().getName();
+      assertNotNull(lastSiteThread.get());
+      assertNotNull(callbackThread.get());
+      assertTrue(lastSiteThread.get().startsWith("three-site-chain-"));
+      assertTrue(callbackThread.get().startsWith("three-site-chain-"));
+      assertEquals("lastSiteThread is same as callbackThread", lastSiteThread.get(), callbackThread.get());
+      assertNotEquals("user callback must not run on the junit thread", junitThread, callbackThread.get());
     } finally {
       impl.shutdown();
     }

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImplTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/MasterSlaveYakPipelinedStoreImplTest.java
@@ -1,0 +1,540 @@
+package com.flipkart.yak.client.pipelined;
+
+import com.flipkart.yak.client.pipelined.models.PipelineConfig;
+import com.flipkart.yak.client.pipelined.models.PipelinedResponse;
+import com.flipkart.yak.client.pipelined.models.StoreOperationResponse;
+import com.flipkart.yak.models.BatchData;
+import com.flipkart.yak.models.BatchDataBuilder;
+import com.flipkart.yak.models.Cell;
+import com.flipkart.yak.models.CheckAndStoreData;
+import com.flipkart.yak.models.ColumnsMap;
+import com.flipkart.yak.models.DeleteData;
+import com.flipkart.yak.models.DeleteDataBuilder;
+import com.flipkart.yak.models.GetByIndexBuilder;
+import com.flipkart.yak.models.GetCellByIndex;
+import com.flipkart.yak.models.GetColumnsMapByIndex;
+import com.flipkart.yak.models.GetDataBuilder;
+import com.flipkart.yak.models.GetRow;
+import com.flipkart.yak.models.IncrementData;
+import com.flipkart.yak.models.IncrementDataBuilder;
+import com.flipkart.yak.models.ResultMap;
+import com.flipkart.yak.models.ScanData;
+import com.flipkart.yak.models.ScanDataBuilder;
+import com.flipkart.yak.models.SimpleIndexAttributes;
+import com.flipkart.yak.models.CheckAndDeleteData;
+import com.flipkart.yak.models.StoreData;
+import com.flipkart.yak.models.StoreDataBuilder;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.apache.hadoop.hbase.filter.ColumnPrefixFilter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Executor queue checks and, for each pipelined primitive, happy/failure paths through
+ * {@code CompletableFuture.whenComplete} into the supplied {@code BiConsumer}.
+ */
+@PowerMockIgnore({ "java.lang.*", "javax.management.*" })
+public class MasterSlaveYakPipelinedStoreImplTest extends PipelinedClientBaseTest {
+
+  private StoreData putData;
+  private List<StoreData> putListOneRow;
+  private BatchData batchData;
+  private DeleteData deleteOne;
+  private List<DeleteData> deleteListOneRow;
+  private GetRow getRow;
+  private List<GetRow> getRowListOne;
+  private IncrementData incrementData;
+  private ResultMap resultMap;
+  private CheckAndStoreData checkAndPutData;
+  private CheckAndDeleteData checkAndDeleteData;
+  private ScanData scanData;
+  private Map<String, ResultMap> scanResult;
+  private GetColumnsMapByIndex columnsMapByIndex;
+  private List<ColumnsMap> indexColumnsResult;
+  private GetCellByIndex cellByIndex;
+  private List<Cell> indexCellsResult;
+  private StoreData appendData;
+
+  @Parameterized.Parameters(name = "hystrix={0}, intent={1}")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(new Object[][] { { false, false } });
+  }
+
+  public MasterSlaveYakPipelinedStoreImplTest(boolean runWithHystrix, boolean runWithIntent) {
+    this.runWithHystrix = runWithHystrix;
+    this.runWithIntent = runWithIntent;
+  }
+
+  @Before
+  public void setupPrimitivePayloads() {
+    putData =
+        new StoreDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).addColumn(cf1, cq1, qv1.getBytes()).build();
+    putListOneRow = Collections.singletonList(putData);
+
+    DeleteData batchDelete = new DeleteDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey2.getBytes()).build();
+    batchData = new BatchDataBuilder(FULL_TABLE_NAME).addStoreData(putData).addDeleteData(batchDelete).build();
+
+    deleteOne = new DeleteDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).build();
+    deleteListOneRow = Collections.singletonList(deleteOne);
+
+    getRow = new GetDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).build();
+    getRowListOne = Collections.singletonList(getRow);
+
+    incrementData = new IncrementDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes())
+        .addColumn(cf1.getBytes(), cq1.getBytes(), 1L).build();
+
+    resultMap = buildResultMap(rowKey1, cf1, cq1, qv1);
+
+    checkAndPutData =
+        new StoreDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).addColumn(cf1, cq1, "2".getBytes())
+            .buildWithCheckAndVerifyColumn(cf1, cq1, qv1.getBytes(), CompareOperator.EQUAL.name());
+
+    checkAndDeleteData = new DeleteDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes())
+        .buildWithCheckAndVerifyColumn(cf1, cq1, qv1.getBytes(), CompareOperator.EQUAL.name());
+
+    FilterList filterList = new FilterList();
+    filterList.addFilter(new ColumnPrefixFilter(rowKey1.getBytes()));
+    scanData = new ScanDataBuilder(FULL_TABLE_NAME).withFilterList(filterList).withLimit(1).build();
+    scanResult = new HashMap<>();
+    scanResult.put(rowKey1, resultMap);
+
+    ColumnsMap map1 = new ColumnsMap();
+    map1.put(cq1, new Cell(qv1.getBytes()));
+    indexColumnsResult = Collections.singletonList(map1);
+    columnsMapByIndex =
+        new GetByIndexBuilder(FULL_TABLE_NAME, cf1).withIndexKey(indexKey1, new SimpleIndexAttributes()).build();
+
+    indexCellsResult = Collections.singletonList(new Cell(qv1.getBytes()));
+    cellByIndex = new GetByIndexBuilder(FULL_TABLE_NAME, cf1).withIndexKey(indexKey1, new SimpleIndexAttributes())
+        .buildForCloumn(cq1);
+
+    appendData =
+        new StoreDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).addColumn(cf1, cq1, qv1.getBytes()).build();
+  }
+
+  private static ThreadPoolExecutor executorFrom(MasterSlaveYakPipelinedStoreImpl<?, ?, ?> impl) throws Exception {
+    Field f = MasterSlaveYakPipelinedStoreImpl.class.getDeclaredField("executor");
+    f.setAccessible(true);
+    return (ThreadPoolExecutor) f.get(impl);
+  }
+
+  private static <T> CompletableFuture<T> failedFuture(Throwable t) {
+    CompletableFuture<T> f = new CompletableFuture<>();
+    f.completeExceptionally(t);
+    return f;
+  }
+
+  @After
+  public void shutdownStore() throws IOException, InterruptedException {
+    if (store != null) {
+      store.shutdown();
+    }
+  }
+
+  @Test
+  public void executorWorkQueueIsUnboundedWhenExecutorQueueCapacityUnset() throws Exception {
+    assertTrue(store instanceof MasterSlaveYakPipelinedStoreImpl);
+    ThreadPoolExecutor ex = executorFrom((MasterSlaveYakPipelinedStoreImpl<?, ?, ?>) store);
+    assertTrue(ex.getQueue() instanceof LinkedBlockingQueue);
+    assertEquals(Integer.MAX_VALUE, ((LinkedBlockingQueue<?>) ex.getQueue()).remainingCapacity());
+  }
+
+  @Test
+  public void executorWorkQueueMatchesPipelineConfigCapacity() throws Exception {
+    int capacity = 17;
+    PipelineConfig boundedConfig =
+        new PipelineConfig(buildConfig(), timeout, poolSize, STORE_NAME, Optional.of(keyDistributorMap),
+            siteBootstrapRetryCount, siteBootstrapRetryDelayInMillis, capacity);
+    MasterSlaveYakPipelinedStoreImpl<?, ?, ?> impl =
+        new MasterSlaveYakPipelinedStoreImpl<>(boundedConfig, storeRoute, registry);
+    try {
+      ThreadPoolExecutor ex = executorFrom(impl);
+      LinkedBlockingQueue<?> q = (LinkedBlockingQueue<?>) ex.getQueue();
+      assertEquals(capacity, q.remainingCapacity() + q.size());
+      assertEquals(capacity, q.remainingCapacity());
+    } finally {
+      impl.shutdown();
+    }
+  }
+
+  @Test
+  public void putSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.put(eq(putData))).thenReturn(CompletableFuture.completedFuture(null));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> done = new CompletableFuture<>();
+    store.put(putData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertVoidSuccess(done.get());
+    verify(region1SiteAClient, times(1)).put(putData);
+  }
+
+  @Test
+  public void putClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("put failed");
+    when(region1SiteAClient.put(eq(putData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> done = new CompletableFuture<>();
+    store.put(putData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertVoidFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).put(putData);
+  }
+
+  @Test
+  public void incrementSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.increment(eq(incrementData))).thenReturn(CompletableFuture.completedFuture(resultMap));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> done = new CompletableFuture<>();
+    store.increment(incrementData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<ResultMap>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(resultMap, r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).increment(incrementData);
+  }
+
+  @Test
+  public void incrementClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("increment failed");
+    when(region1SiteAClient.increment(eq(incrementData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> done = new CompletableFuture<>();
+    store.increment(incrementData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).increment(incrementData);
+  }
+
+  @Test
+  public void batchSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.batch(eq(batchData))).thenReturn(CompletableFuture.completedFuture(null));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> done = new CompletableFuture<>();
+    store.batch(batchData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertVoidSuccess(done.get());
+    verify(region1SiteAClient, times(1)).batch(batchData);
+  }
+
+  @Test
+  public void batchClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("batch failed");
+    when(region1SiteAClient.batch(eq(batchData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Void>>> done = new CompletableFuture<>();
+    store.batch(batchData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertVoidFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).batch(batchData);
+  }
+
+  @Test
+  public void batchPutListSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.put(eq(putListOneRow)))
+        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(null)));
+    CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> done = new CompletableFuture<>();
+    store.put(putListOneRow, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(done));
+    PipelinedResponse<List<StoreOperationResponse<Void>>> r = done.get();
+    assertEquals(1, r.getOperationResponse().size());
+    assertNull(r.getOperationResponse().get(0).getError());
+    assertEquals(Region1SiteA, r.getOperationResponse().get(0).getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).put(putListOneRow);
+  }
+
+  @Test
+  public void batchPutListClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("batch put failed");
+    when(region1SiteAClient.put(eq(putListOneRow)))
+        .thenReturn(Collections.singletonList(failedFuture(failure)));
+    CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> done = new CompletableFuture<>();
+    store.put(putListOneRow, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(done));
+    PipelinedResponse<List<StoreOperationResponse<Void>>> r = done.get();
+    assertEquals(1, r.getOperationResponse().size());
+    assertEquals(failure, r.getOperationResponse().get(0).getError());
+    verify(region1SiteAClient, times(1)).put(putListOneRow);
+  }
+
+  @Test
+  public void checkAndPutSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.checkAndPut(eq(checkAndPutData))).thenReturn(CompletableFuture.completedFuture(true));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> done = new CompletableFuture<>();
+    store.checkAndPut(checkAndPutData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<Boolean>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertTrue(r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).checkAndPut(checkAndPutData);
+  }
+
+  @Test
+  public void checkAndPutClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("cas put failed");
+    when(region1SiteAClient.checkAndPut(eq(checkAndPutData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> done = new CompletableFuture<>();
+    store.checkAndPut(checkAndPutData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).checkAndPut(checkAndPutData);
+  }
+
+  @Test
+  public void appendSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.append(eq(appendData))).thenReturn(CompletableFuture.completedFuture(resultMap));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> done = new CompletableFuture<>();
+    store.append(appendData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<ResultMap>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(resultMap, r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).append(appendData);
+  }
+
+  @Test
+  public void appendClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("append failed");
+    when(region1SiteAClient.append(eq(appendData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> done = new CompletableFuture<>();
+    store.append(appendData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).append(appendData);
+  }
+
+  @Test
+  public void batchDeleteListSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.delete(eq(deleteListOneRow)))
+        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(null)));
+    CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> done = new CompletableFuture<>();
+    store.delete(deleteListOneRow, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(done));
+    PipelinedResponse<List<StoreOperationResponse<Void>>> r = done.get();
+    assertEquals(1, r.getOperationResponse().size());
+    assertNull(r.getOperationResponse().get(0).getError());
+    assertEquals(Region1SiteA, r.getOperationResponse().get(0).getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).delete(deleteListOneRow);
+  }
+
+  @Test
+  public void batchDeleteListClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("batch delete failed");
+    when(region1SiteAClient.delete(eq(deleteListOneRow)))
+        .thenReturn(Collections.singletonList(failedFuture(failure)));
+    CompletableFuture<PipelinedResponse<List<StoreOperationResponse<Void>>>> done = new CompletableFuture<>();
+    store.delete(deleteListOneRow, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(done));
+    PipelinedResponse<List<StoreOperationResponse<Void>>> r = done.get();
+    assertEquals(1, r.getOperationResponse().size());
+    assertEquals(failure, r.getOperationResponse().get(0).getError());
+    verify(region1SiteAClient, times(1)).delete(deleteListOneRow);
+  }
+
+  @Test
+  public void checkAndDeleteSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.checkAndDelete(eq(checkAndDeleteData))).thenReturn(CompletableFuture.completedFuture(true));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> done = new CompletableFuture<>();
+    store.checkAndDelete(checkAndDeleteData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<Boolean>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertTrue(r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).checkAndDelete(checkAndDeleteData);
+  }
+
+  @Test
+  public void checkAndDeleteClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("check delete failed");
+    when(region1SiteAClient.checkAndDelete(eq(checkAndDeleteData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Boolean>>> done = new CompletableFuture<>();
+    store.checkAndDelete(checkAndDeleteData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).checkAndDelete(checkAndDeleteData);
+  }
+
+  @Test
+  public void scanSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.scan(eq(scanData))).thenReturn(CompletableFuture.completedFuture(scanResult));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> done = new CompletableFuture<>();
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(scanResult, r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).scan(scanData);
+  }
+
+  @Test
+  public void scanClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("scan failed");
+    when(region1SiteAClient.scan(eq(scanData))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>>> done = new CompletableFuture<>();
+    store.scan(scanData, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<Map<String, ResultMap>>> r = done.get();
+    assertNotNull(r.getOperationResponse().getError());
+    assertEquals(failure, r.getOperationResponse().getError());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    verify(region1SiteAClient, times(1)).scan(scanData);
+  }
+
+  @Test
+  public void getSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.get(eq(getRow))).thenReturn(CompletableFuture.completedFuture(resultMap));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> done = new CompletableFuture<>();
+    store.get(getRow, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<ResultMap>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(resultMap, r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).get(getRow);
+  }
+
+  @Test
+  public void getClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("get failed");
+    when(region1SiteAClient.get(eq(getRow))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<ResultMap>>> done = new CompletableFuture<>();
+    store.get(getRow, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).get(getRow);
+  }
+
+  @Test
+  public void batchGetListSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.get(eq(getRowListOne)))
+        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(resultMap)));
+    CompletableFuture<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>> done = new CompletableFuture<>();
+    store.get(getRowListOne, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(done));
+    PipelinedResponse<List<StoreOperationResponse<ResultMap>>> r = done.get();
+    assertEquals(1, r.getOperationResponse().size());
+    assertNull(r.getOperationResponse().get(0).getError());
+    assertEquals(resultMap, r.getOperationResponse().get(0).getValue());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).get(getRowListOne);
+  }
+
+  @Test
+  public void batchGetListClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("batch get failed");
+    when(region1SiteAClient.get(eq(getRowListOne)))
+        .thenReturn(Collections.singletonList(failedFuture(failure)));
+    CompletableFuture<PipelinedResponse<List<StoreOperationResponse<ResultMap>>>> done = new CompletableFuture<>();
+    store.get(getRowListOne, routeMetaChOptional, Optional.empty(), hystrixSettings, responsesHandler(done));
+    PipelinedResponse<List<StoreOperationResponse<ResultMap>>> r = done.get();
+    assertEquals(1, r.getOperationResponse().size());
+    assertEquals(failure, r.getOperationResponse().get(0).getError());
+    verify(region1SiteAClient, times(1)).get(getRowListOne);
+  }
+
+  @Test
+  public void getByIndexColumnsSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.getByIndex(eq(columnsMapByIndex)))
+        .thenReturn(CompletableFuture.completedFuture(indexColumnsResult));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> done = new CompletableFuture<>();
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(indexColumnsResult, r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).getByIndex(columnsMapByIndex);
+  }
+
+  @Test
+  public void getByIndexColumnsClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("getByIndex columns failed");
+    when(region1SiteAClient.getByIndex(eq(columnsMapByIndex))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<List<ColumnsMap>>>> done = new CompletableFuture<>();
+    store.getByIndex(columnsMapByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).getByIndex(columnsMapByIndex);
+  }
+
+  @Test
+  public void getByIndexCellSuccessRunsWhenCompleteAndDeliversPipelinedResponse() throws Exception {
+    assertImpl();
+    when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(CompletableFuture.completedFuture(indexCellsResult));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> done = new CompletableFuture<>();
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    PipelinedResponse<StoreOperationResponse<List<Cell>>> r = done.get();
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(indexCellsResult, r.getOperationResponse().getValue());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+    verify(region1SiteAClient, times(1)).getByIndex(cellByIndex);
+  }
+
+  @Test
+  public void getByIndexCellClientFailureRunsWhenCompleteAndDeliversErrorInResponse() throws Exception {
+    assertImpl();
+    RuntimeException failure = new RuntimeException("getByIndex cell failed");
+    when(region1SiteAClient.getByIndex(eq(cellByIndex))).thenReturn(failedFuture(failure));
+    CompletableFuture<PipelinedResponse<StoreOperationResponse<List<Cell>>>> done = new CompletableFuture<>();
+    store.getByIndex(cellByIndex, routeMetaChOptional, Optional.empty(), hystrixSettings, responseHandler(done));
+    assertFailure(done.get(), failure);
+    verify(region1SiteAClient, times(1)).getByIndex(cellByIndex);
+  }
+
+  private void assertImpl() {
+    assertTrue(store instanceof MasterSlaveYakPipelinedStoreImpl);
+  }
+
+  private void assertVoidSuccess(PipelinedResponse<StoreOperationResponse<Void>> r) {
+    assertNull(r.getOperationResponse().getError());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+    assertFalse(r.isStale());
+  }
+
+  private void assertVoidFailure(PipelinedResponse<StoreOperationResponse<Void>> r, Throwable failure) {
+    assertNotNull(r.getOperationResponse().getError());
+    assertEquals(failure, r.getOperationResponse().getError());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+  }
+
+  private <T> void assertFailure(PipelinedResponse<StoreOperationResponse<T>> r, Throwable failure) {
+    assertNotNull(r.getOperationResponse().getError());
+    assertEquals(failure, r.getOperationResponse().getError());
+    assertEquals(Region1SiteA, r.getOperationResponse().getSite());
+  }
+}

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchPutTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/PipelinedClientBatchPutTest.java
@@ -12,9 +12,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static junit.framework.Assert.assertNotNull;

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/SyncYakPipelinedStoreImplTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/SyncYakPipelinedStoreImplTest.java
@@ -1,0 +1,77 @@
+package com.flipkart.yak.client.pipelined;
+
+import com.flipkart.yak.models.CheckAndStoreData;
+import com.flipkart.yak.models.StoreDataBuilder;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.mockito.Matchers;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+/**
+ * {@link SyncYakPipelinedStoreImpl} coverage. Uses the same PowerMock + {@link BlockJUnit4ClassRunner} pattern as
+ * {@link MasterSlaveYakPipelinedStoreImplTest} so single-method runs work in IntelliJ.
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(BlockJUnit4ClassRunner.class)
+public class SyncYakPipelinedStoreImplTest extends PipelinedClientBaseTest {
+
+  @After
+  public void tearDown() throws IOException, InterruptedException {
+    if (store != null) {
+      store.shutdown();
+    }
+  }
+
+  /**
+   * Runs the real master/slave {@code checkAndPut} pipeline. The primary site’s client returns a
+   * {@link CompletableFuture} that never completes, so the composed async chain never finishes and the user
+   * callback is never invoked. {@link SyncYakPipelinedStoreImpl} should then block until the write timeout and throw
+   * {@link TimeoutException}. Downstream sites must not be hit.
+   */
+  @Test
+  public void checkAndPutTimesOutWhenFirstSiteFutureNeverCompletes() throws Exception {
+    int writeTimeoutMs = 30;
+    CheckAndStoreData data =
+        new StoreDataBuilder(FULL_TABLE_NAME).withRowKey(rowKey1.getBytes()).addColumn(cf1, cq1, "2".getBytes())
+            .buildWithCheckAndVerifyColumn(cf1, cq1, qv1.getBytes(), CompareOperator.EQUAL.name());
+
+    CompletableFuture<Boolean> hanging = new CompletableFuture<>();
+    when(region1SiteAClient.checkAndPut(eq(data))).thenReturn(hanging);
+
+    SyncYakPipelinedStoreImpl syncWithShortTimeout =
+        new SyncYakPipelinedStoreImpl(store).setWriteTimeoutInMillis(writeTimeoutMs);
+
+    long startNanos = System.nanoTime();
+    try {
+      syncWithShortTimeout.checkAndPut(data, routeMetaChOptional, Optional.empty(), Optional.empty());
+      fail("Expected TimeoutException when first-site async never completes");
+    } catch (TimeoutException expected) {
+      long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+      assertTrue(
+          "Should wait at least writeTimeoutMs (elapsedMillis=" + elapsedMillis + ")",
+          elapsedMillis >= writeTimeoutMs);
+    }
+
+    verify(region1SiteAClient, times(1)).checkAndPut(eq(data));
+    verify(region1SiteBClient, never()).checkAndPut(Matchers.any(CheckAndStoreData.class));
+    verify(region2SiteAClient, never()).checkAndPut(Matchers.any(CheckAndStoreData.class));
+  }
+}

--- a/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/models/PipelineConfigTest.java
+++ b/pipelined-client/src/test/java/com/flipkart/yak/client/pipelined/models/PipelineConfigTest.java
@@ -1,0 +1,47 @@
+package com.flipkart.yak.client.pipelined.models;
+
+import com.flipkart.yak.client.pipelined.config.MultiRegionStoreConfig;
+import java.util.Optional;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link PipelineConfig}.
+ */
+public class PipelineConfigTest {
+
+  private static MultiRegionStoreConfig minimalMultiRegion() {
+    return new MultiRegionStoreConfig();
+  }
+
+  @Test
+  public void executorQueueCapacityDefaultsToZero() {
+    PipelineConfig config =
+        new PipelineConfig(minimalMultiRegion(), 30, 10, "test-store", Optional.empty(), 3, 3000L);
+    assertEquals(0, config.getExecutorQueueCapacity());
+  }
+
+  @Test
+  public void storesConfiguredExecutorQueueCapacity() {
+    PipelineConfig config = new PipelineConfig(minimalMultiRegion(), 30, 10, "test-store", Optional.empty(), 3, 3000L, 64);
+    assertEquals(64, config.getExecutorQueueCapacity());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectsZeroExecutorQueueCapacity() {
+    new PipelineConfig(minimalMultiRegion(), 30, 10, "test-store", Optional.empty(), 3, 3000L, 0);
+  }
+
+  @Test
+  public void rejectsNegativeExecutorQueueCapacity() {
+    try {
+      new PipelineConfig(minimalMultiRegion(), 30, 10, "test-store", Optional.empty(), 3, 3000L, -1);
+    } catch (IllegalArgumentException ex) {
+      assertTrue(ex.getMessage().contains("executorQueueCapacity"));
+      return;
+    }
+    org.junit.Assert.fail("expected IllegalArgumentException");
+  }
+}


### PR DESCRIPTION
Adds an optional executor work-queue capacity to the pipelined store so clients can use a bounded LinkedBlockingQueue for the thread pool. Clients that do not set it keep the current unbounded behaviour, so existing usage is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable executor queue capacity for the pipelined client: 0 = unbounded, positive = bounded to control resource usage.
  * New configuration option and accessors to set and retrieve the capacity.
  * Validation added to prevent negative values; existing behavior unchanged when not configured.
  * Thread naming and runtime behavior otherwise unchanged; no breaking changes to existing APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->