### PR TITLE
Isolated avro dependency via shading to resolve classpath conflicts

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>client-modules</artifactId>
         <groupId>com.flipkart.yak</groupId>
-        <version>5.2.1</version>
+        <version>5.2.2</version>
     </parent>
 
     <artifactId>client</artifactId>
@@ -194,6 +194,10 @@
                                 </excludes>
                             </artifactSet>
                             <relocations>
+                                <relocation>
+                                    <pattern>org.apache.avro</pattern>
+                                    <shadedPattern>${shaded.prefix}.org.apache.avro</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>${shaded.prefix}.com.google</shadedPattern>

--- a/pipelined-client/pom.xml
+++ b/pipelined-client/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <artifactId>client-modules</artifactId>
         <groupId>com.flipkart.yak</groupId>
-        <version>5.2.1</version>
+        <version>5.2.2</version>
     </parent>
     <dependencies>
         <dependency>
             <groupId>com.flipkart.yak</groupId>
             <artifactId>client</artifactId>
-            <version>5.2.1</version>
+            <version>5.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.netflix.hystrix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>client-modules</artifactId>
     <groupId>com.flipkart.yak</groupId>
-    <version>5.2.1</version>
+    <version>5.2.2</version>
     <packaging>pom</packaging>
     <modules>
         <module>client</module>


### PR DESCRIPTION
Summary
Purpose: This PR aims to update the project version from 5.2.1 to 5.2.2 across the yak-client modules. Additionally, it addresses potential dependency conflicts by shading the org.apache.avro library within the client module.

Changes:

Version Updates: The parent and artifact versions have been uniformly updated to 5.2.2 in modules/client/pom.xml, modules/pipelined-client/pom.xml, modules/pom.xml. This includes updates to inter-module dependencies to reflect the new version.
Dependency Shading: A new relocation rule for org.apache.avro has been added to the maven-shade-plugin configuration within modules/client/pom.xml. This rule re-packages Avro classes under the com.flipkart.yak.client.shaded.org.apache.avro namespace, effectively isolating the client's Avro dependency and preventing conflicts with other versions of Avro in consuming applications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 5.2.2 across all modules
  * Aligned client module dependency versions with parent release
  * Updated build configuration for dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->